### PR TITLE
Upgrade @testing-library/dom to latest (7.1) version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "Neil Kistner",
     "email": "neil.kistner@gmail.com",
-    "url": "neilkistner.com"
+    "url": "https://neilkistner.com"
   },
   "license": "MIT",
   "files": [
@@ -19,7 +19,7 @@
     "clean": "run-p clean:*",
     "clean:bsb": "bsb -clean-world",
     "clean:project": "rimraf lib .merlin",
-    "jest": "jest",
+    "jest": "jest --setupTestFrameworkScriptFile=./setupTests.js",
     "postversion": "github-release",
     "prebuild": "yarn clean",
     "pretest": "yarn build",
@@ -31,10 +31,11 @@
     "testing"
   ],
   "dependencies": {
-    "@testing-library/dom": "^5.6.0"
+    "@testing-library/dom": "^7.0.3"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",
+    "@sheerun/mutationobserver-shim": "^0.3.3",
     "@wyze/changelog": "^1.0.0",
     "@wyze/github-release": "^1.0.0",
     "bs-platform": "^5.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "testing"
   ],
   "dependencies": {
-    "@testing-library/dom": "^7.0.3"
+    "@testing-library/dom": "^7.1.3"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,3 @@
+const MutationObserver = require('@sheerun/mutationobserver-shim');
+
+window.MutationObserver = MutationObserver;

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -49,6 +49,17 @@ module ByTextQuery: {
     options =
     "";
 };
+module ByAltTextQuery: {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 module MutationObserver: {
   type options = {
     .
@@ -363,13 +374,77 @@ let findAllByText:
 /**
  * ByAltText
  */
-let getByAltText: (string, Dom.element) => Dom.element;
-let getAllByAltText: (string, Dom.element) => Dom.element;
-let queryByAltText: (string, Dom.element) => Dom.element;
-let queryAllByAltText: (string, Dom.element) => Dom.element;
-let findByAltText: (string, Dom.element) => Js.Promise.t(Dom.element);
+let getByAltText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByAltText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByAltText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByAltText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByAltText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
 let findAllByAltText:
-  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByAltTextQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 /**
  * ByTitle

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -83,68 +83,25 @@ module ByDisplayValueQuery: {
     "";
 };
 module ByRoleQuery: {
-  module NameStr: {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined(string),
-      "normalizer": Js.undefined(string => string),
-    };
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: string=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "hidden": Js.undefined(bool),
+    // TODO: add supports for TextMatch
+    "name": Js.undefined(string),
+    "normalizer": Js.undefined(string => string),
   };
-
-  module NameRegExp: {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined(Js.Re.t),
-      "normalizer": Js.undefined(string => string),
-    };
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: Js.Re.t=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
-  };
-
-  module NameFunc: {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined((string, Dom.element) => bool),
-      "normalizer": Js.undefined(string => string),
-    };
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: (string, Dom.element) => bool=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
-  };
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~exact: bool=?,
+      ~hidden: bool=?,
+      ~name: string=?,
+      ~normalizer: string => string=?,
+      unit
+    ) =>
+    options =
+    "";
 };
 module ByTestIdQuery: {
   type options = {
@@ -621,31 +578,224 @@ let findAllByTitle:
 /**
  * ByDisplayValue
  */
-let getByDisplayValue: (string, Dom.element) => Dom.element;
-let getAllByDisplayValue: (string, Dom.element) => Dom.element;
-let queryByDisplayValue: (string, Dom.element) => Dom.element;
-let queryAllByDisplayValue: (string, Dom.element) => Dom.element;
-let findByDisplayValue: (string, Dom.element) => Js.Promise.t(Dom.element);
+let getByDisplayValue:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByDisplayValue:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByDisplayValue:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByDisplayValue:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByDisplayValue:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
 let findAllByDisplayValue:
-  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByDisplayValueQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 /**
  * ByRole
  */
-let getByRole: (string, Dom.element) => Dom.element;
-let getAllByRole: (string, Dom.element) => Dom.element;
-let queryByRole: (string, Dom.element) => Dom.element;
-let queryAllByRole: (string, Dom.element) => Dom.element;
-let findByRole: (string, Dom.element) => Js.Promise.t(Dom.element);
-let findAllByRole: (string, Dom.element) => Js.Promise.t(array(Dom.element));
+let getByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
+let findAllByRole:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByRoleQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 /**
  * ByTestId
  */
-let getByTestId: (string, Dom.element) => Dom.element;
-let getAllByTestId: (string, Dom.element) => Dom.element;
-let queryByTestId: (string, Dom.element) => Dom.element;
-let queryAllByTestId: (string, Dom.element) => Dom.element;
-let findByTestId: (string, Dom.element) => Js.Promise.t(Dom.element);
+let getByTestId:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByTestId:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByTestId:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByTestId:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByTestId:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
 let findAllByTestId:
-  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTestIdQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -60,6 +60,17 @@ module ByAltTextQuery: {
     (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
     "";
 };
+module ByTitleQuery: {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 module MutationObserver: {
   type options = {
     .
@@ -449,13 +460,77 @@ let findAllByAltText:
 /**
  * ByTitle
  */
-let getByTitle: (string, Dom.element) => Dom.element;
-let getAllByTitle: (string, Dom.element) => Dom.element;
-let queryByTitle: (string, Dom.element) => Dom.element;
-let queryAllByTitle: (string, Dom.element) => Dom.element;
-let findByTitle: (string, Dom.element) => Js.Promise.t(Dom.element);
+let getByTitle:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByTitle:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByTitle:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByTitle:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByTitle:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
 let findAllByTitle:
-  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByTitleQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 /**
  * ByDisplayValue

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -18,6 +18,17 @@ module ByLabelTextQuery: {
     options =
     "";
 };
+module ByPlaceholderTextQuery: {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 module ByTextQuery: {
   type options = {
     .
@@ -202,13 +213,77 @@ let findAllByLabelText:
 /**
  * ByPlaceholderText
  */
-let getByPlaceholderText: (string, Dom.element) => Dom.element;
-let getAllByPlaceholderText: (string, Dom.element) => Dom.element;
-let queryByPlaceholderText: (string, Dom.element) => Dom.element;
-let queryAllByPlaceholderText: (string, Dom.element) => Dom.element;
-let findByPlaceholderText: (string, Dom.element) => Js.Promise.t(Dom.element);
+let getByPlaceholderText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByPlaceholderText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByPlaceholderText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByPlaceholderText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByPlaceholderText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
 let findAllByPlaceholderText:
-  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: ByPlaceholderTextQuery.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 /**
  * ByText

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -198,7 +198,7 @@ let configure:
   unit;
 
 [@bs.module "@testing-library/dom"]
-external getNodeText: Dom.element => string = "";
+external getNodeText: Dom.element => string = "getNodeText";
 
 /**
  * ByLabelText

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -71,6 +71,92 @@ module ByTitleQuery: {
     (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
     "";
 };
+module ByDisplayValueQuery: {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
+module ByRoleQuery: {
+  module NameStr: {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined(string),
+      "normalizer": Js.undefined(string => string),
+    };
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: string=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+
+  module NameRegExp: {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined(Js.Re.t),
+      "normalizer": Js.undefined(string => string),
+    };
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: Js.Re.t=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+
+  module NameFunc: {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined((string, Dom.element) => bool),
+      "normalizer": Js.undefined(string => string),
+    };
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: (string, Dom.element) => bool=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+};
+module ByTestIdQuery: {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 module MutationObserver: {
   type options = {
     .

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -3,20 +3,18 @@ module FireEvent = DomTestingLibrary__FireEvent;
 module Query: {
   type options = {
     .
-    "collapseWhitespace": Js.undefined(bool),
     "exact": Js.undefined(bool),
     "selector": Js.undefined(string),
-    "trim": Js.undefined(bool),
     "ignore": Js.undefined(string),
+    "normalizer": Js.undefined(string => string),
   };
   [@bs.obj]
   external makeOptions:
     (
-      ~collapseWhitespace: bool=?,
       ~exact: bool=?,
       ~selector: string=?,
-      ~trim: bool=?,
       ~ignore: string=?,
+      ~normalizer: string => string=?,
       unit
     ) =>
     options =

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -1,6 +1,24 @@
 module FireEvent = DomTestingLibrary__FireEvent;
 
-module Query: {
+module ByLabelTextQuery: {
+  type options = {
+    .
+    "selector": Js.undefined(string),
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~selector: string=?,
+      ~exact: bool=?,
+      ~normalizer: string => string=?,
+      unit
+    ) =>
+    options =
+    "";
+};
+module ByTextQuery: {
   type options = {
     .
     "exact": Js.undefined(bool),
@@ -116,7 +134,7 @@ let getByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -128,7 +146,7 @@ let getAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -140,7 +158,7 @@ let queryByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -152,7 +170,7 @@ let queryAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -164,7 +182,7 @@ let findByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Js.Promise.t(Dom.element);
@@ -176,7 +194,7 @@ let findAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
   Js.Promise.t(array(Dom.element));
@@ -202,7 +220,7 @@ let getByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -214,7 +232,7 @@ let getAllByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -226,7 +244,7 @@ let queryByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -238,7 +256,7 @@ let queryAllByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Dom.element;
@@ -250,7 +268,7 @@ let findByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Js.Promise.t(Dom.element);
@@ -262,7 +280,7 @@ let findAllByText:
                 | `RegExp(Js.Re.t)
                 | `Str(string)
               ],
-    ~options: Query.options=?,
+    ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
   Js.Promise.t(array(Dom.element));

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -108,6 +108,9 @@ let configure:
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";
 
+/**
+ * ByLabelText
+ */
 let getByLabelText:
   (
     ~matcher: [
@@ -180,6 +183,9 @@ let findAllByLabelText:
   ) =>
   Js.Promise.t(array(Dom.element));
 
+/**
+ * ByPlaceholderText
+ */
 let getByPlaceholderText: (string, Dom.element) => Dom.element;
 let getAllByPlaceholderText: (string, Dom.element) => Dom.element;
 let queryByPlaceholderText: (string, Dom.element) => Dom.element;
@@ -188,6 +194,9 @@ let findByPlaceholderText: (string, Dom.element) => Js.Promise.t(Dom.element);
 let findAllByPlaceholderText:
   (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
+/**
+ * ByText
+ */
 let getByText:
   (
     ~matcher: [
@@ -260,6 +269,9 @@ let findAllByText:
   ) =>
   Js.Promise.t(array(Dom.element));
 
+/**
+ * ByAltText
+ */
 let getByAltText: (string, Dom.element) => Dom.element;
 let getAllByAltText: (string, Dom.element) => Dom.element;
 let queryByAltText: (string, Dom.element) => Dom.element;
@@ -268,6 +280,9 @@ let findByAltText: (string, Dom.element) => Js.Promise.t(Dom.element);
 let findAllByAltText:
   (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
+/**
+ * ByTitle
+ */
 let getByTitle: (string, Dom.element) => Dom.element;
 let getAllByTitle: (string, Dom.element) => Dom.element;
 let queryByTitle: (string, Dom.element) => Dom.element;
@@ -276,6 +291,9 @@ let findByTitle: (string, Dom.element) => Js.Promise.t(Dom.element);
 let findAllByTitle:
   (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
+/**
+ * ByDisplayValue
+ */
 let getByDisplayValue: (string, Dom.element) => Dom.element;
 let getAllByDisplayValue: (string, Dom.element) => Dom.element;
 let queryByDisplayValue: (string, Dom.element) => Dom.element;
@@ -284,6 +302,9 @@ let findByDisplayValue: (string, Dom.element) => Js.Promise.t(Dom.element);
 let findAllByDisplayValue:
   (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
+/**
+ * ByRole
+ */
 let getByRole: (string, Dom.element) => Dom.element;
 let getAllByRole: (string, Dom.element) => Dom.element;
 let queryByRole: (string, Dom.element) => Dom.element;
@@ -291,6 +312,9 @@ let queryAllByRole: (string, Dom.element) => Dom.element;
 let findByRole: (string, Dom.element) => Js.Promise.t(Dom.element);
 let findAllByRole: (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
+/**
+ * ByTestId
+ */
 let getByTestId: (string, Dom.element) => Dom.element;
 let getAllByTestId: (string, Dom.element) => Dom.element;
 let queryByTestId: (string, Dom.element) => Dom.element;

--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -22,18 +22,8 @@ module Query: {
     options =
     "";
 };
-module Wait: {
+module MutationObserver: {
   type options = {
-    .
-    "interval": Js.undefined(int),
-    "timeout": Js.undefined(int),
-  };
-  [@bs.obj]
-  external makeOptions: (~interval: int=?, ~timeout: int=?, unit) => options =
-    "";
-};
-module WaitForElement: {
-  type mutationObserverOptions = {
     .
     "attributeFilter": Js.undefined(array(string)),
     "attributeOldValue": Js.undefined(bool),
@@ -42,23 +32,8 @@ module WaitForElement: {
     "characterDataOldValue": Js.undefined(bool),
     "subtree": Js.undefined(bool),
   };
-  type options = {
-    .
-    "container": Js.undefined(Dom.element),
-    "timeout": Js.undefined(int),
-  };
   [@bs.obj]
   external makeOptions:
-    (
-      ~container: Dom.element=?,
-      ~mutationObserverInit: mutationObserverOptions=?,
-      ~timeout: int=?,
-      unit
-    ) =>
-    options =
-    "";
-  [@bs.obj]
-  external makeMutationObserverOptions:
     (
       ~attributeFilter: array(string)=?,
       ~attributeOldValue: bool=?,
@@ -68,12 +43,49 @@ module WaitForElement: {
       ~subtree: bool=?,
       unit
     ) =>
-    mutationObserverOptions =
+    options =
+    "";
+};
+module WaitFor: {
+  type options = {
+    .
+    "container": Js.undefined(Dom.element),
+    "interval": Js.undefined(int),
+    "timeout": Js.undefined(int),
+    "mutationObserverOptions": Js.undefined(MutationObserver.options),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~container: Dom.element=?,
+      ~interval: int=?,
+      ~timeout: int=?,
+      ~mutationObserverOptions: MutationObserver.options=?,
+      unit
+    ) =>
+    options =
+    "";
+};
+module WaitForElement: {
+  type options = {
+    .
+    "container": Js.undefined(Dom.element),
+    "timeout": Js.undefined(int),
+  };
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~container: Dom.element=?,
+      ~mutationObserverInit: MutationObserver.options=?,
+      ~timeout: int=?,
+      unit
+    ) =>
+    options =
     "";
 };
 
-let wait:
-  (~callback: unit => unit=?, ~options: Wait.options=?, unit) =>
+let waitFor:
+  (~callback: unit => unit=?, ~options: WaitFor.options=?, unit) =>
   Js.Promise.t('a);
 
 let waitForElement:
@@ -96,15 +108,85 @@ let configure:
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";
 
-let getByTestId: (string, Dom.element) => Dom.element;
+let getByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let getAllByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
+let findAllByLabelText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
 
 let getByPlaceholderText: (string, Dom.element) => Dom.element;
-
-let getByAltText: (string, Dom.element) => Dom.element;
-
-let getByTitle: (string, Dom.element) => Dom.element;
-
-let getByDisplayValue: (string, Dom.element) => Dom.element;
+let getAllByPlaceholderText: (string, Dom.element) => Dom.element;
+let queryByPlaceholderText: (string, Dom.element) => Dom.element;
+let queryAllByPlaceholderText: (string, Dom.element) => Dom.element;
+let findByPlaceholderText: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByPlaceholderText:
+  (string, Dom.element) => Js.Promise.t(array(Dom.element));
 
 let getByText:
   (
@@ -118,7 +200,7 @@ let getByText:
   ) =>
   Dom.element;
 
-let getByLabelText:
+let getAllByText:
   (
     ~matcher: [
                 | `Func((string, Dom.element) => bool)
@@ -129,3 +211,90 @@ let getByLabelText:
     Dom.element
   ) =>
   Dom.element;
+
+let queryByText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let queryAllByText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Dom.element;
+
+let findByText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(Dom.element);
+
+let findAllByText:
+  (
+    ~matcher: [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Query.options=?,
+    Dom.element
+  ) =>
+  Js.Promise.t(array(Dom.element));
+
+let getByAltText: (string, Dom.element) => Dom.element;
+let getAllByAltText: (string, Dom.element) => Dom.element;
+let queryByAltText: (string, Dom.element) => Dom.element;
+let queryAllByAltText: (string, Dom.element) => Dom.element;
+let findByAltText: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByAltText:
+  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+
+let getByTitle: (string, Dom.element) => Dom.element;
+let getAllByTitle: (string, Dom.element) => Dom.element;
+let queryByTitle: (string, Dom.element) => Dom.element;
+let queryAllByTitle: (string, Dom.element) => Dom.element;
+let findByTitle: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByTitle:
+  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+
+let getByDisplayValue: (string, Dom.element) => Dom.element;
+let getAllByDisplayValue: (string, Dom.element) => Dom.element;
+let queryByDisplayValue: (string, Dom.element) => Dom.element;
+let queryAllByDisplayValue: (string, Dom.element) => Dom.element;
+let findByDisplayValue: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByDisplayValue:
+  (string, Dom.element) => Js.Promise.t(array(Dom.element));
+
+let getByRole: (string, Dom.element) => Dom.element;
+let getAllByRole: (string, Dom.element) => Dom.element;
+let queryByRole: (string, Dom.element) => Dom.element;
+let queryAllByRole: (string, Dom.element) => Dom.element;
+let findByRole: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByRole: (string, Dom.element) => Js.Promise.t(array(Dom.element));
+
+let getByTestId: (string, Dom.element) => Dom.element;
+let getAllByTestId: (string, Dom.element) => Dom.element;
+let queryByTestId: (string, Dom.element) => Dom.element;
+let queryAllByTestId: (string, Dom.element) => Dom.element;
+let findByTestId: (string, Dom.element) => Js.Promise.t(Dom.element);
+let findAllByTestId:
+  (string, Dom.element) => Js.Promise.t(array(Dom.element));

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -74,6 +74,96 @@ module ByTitleQuery = {
     (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
     "";
 };
+module ByDisplayValueQuery = {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
+module ByRoleQuery = {
+  module NameStr = {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined(string),
+      "normalizer": Js.undefined(string => string),
+    };
+
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: string=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+
+  module NameRegExp = {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined(Js.Re.t),
+      "normalizer": Js.undefined(string => string),
+    };
+
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: Js.Re.t=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+  module NameFunc = {
+    type options = {
+      .
+      "exact": Js.undefined(bool),
+      "hidden": Js.undefined(bool),
+      "name": Js.undefined((string, Dom.element) => bool),
+      "normalizer": Js.undefined(string => string),
+    };
+
+    [@bs.obj]
+    external makeOptions:
+      (
+        ~exact: bool=?,
+        ~hidden: bool=?,
+        ~name: (string, Dom.element) => bool=?,
+        ~normalizer: string => string=?,
+        unit
+      ) =>
+      options =
+      "";
+  };
+};
+module ByTestIdQuery = {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -1,21 +1,19 @@
 module Query = {
   type options = {
     .
-    "collapseWhitespace": Js.undefined(bool),
     "exact": Js.undefined(bool),
     "selector": Js.undefined(string),
-    "trim": Js.undefined(bool),
     "ignore": Js.undefined(string),
+    "normalizer": Js.undefined(string => string),
   };
 
   [@bs.obj]
   external makeOptions:
     (
-      ~collapseWhitespace: bool=?,
       ~exact: bool=?,
       ~selector: string=?,
-      ~trim: bool=?,
       ~ignore: string=?,
+      ~normalizer: string => string=?,
       unit
     ) =>
     options =

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -25,312 +25,9 @@ module Query = {
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";
 
-[@bs.module "@testing-library/dom"]
-external _getByTestId: (Dom.element, string) => Dom.element = "getByTestId";
-
-let getByTestId = (id, element) => _getByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getAllByTestId: (Dom.element, string) => Dom.element =
-  "getAllByTestId";
-
-let getAllByTestId = (id, element) => _getAllByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getByTitle: (Dom.element, string) => Dom.element = "getByTitle";
-
-let getByTitle = (id, element) => _getByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getAllByTitle: (Dom.element, string) => Dom.element =
-  "getAllByTitle";
-
-let getAllByTitle = (id, element) => _getAllByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryByTitle: (Dom.element, string) => Dom.element = "queryByTitle";
-
-let queryByTitle = (id, element) => _queryByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByTitle: (Dom.element, string) => Dom.element =
-  "queryAllByTitle";
-
-let queryAllByTitle = (id, element) => _queryAllByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findByTitle: (Dom.element, string) => Js.Promise.t(Dom.element) =
-  "findByTitle";
-
-let findByTitle = (id, element) => _findByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findAllByTitle:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
-  "findAllByTitle";
-
-let findAllByTitle = (id, element) => _findAllByTitle(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryByTestId: (Dom.element, string) => Dom.element =
-  "queryByTestId";
-
-let queryByTestId = (id, element) => _queryByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByTestId: (Dom.element, string) => Dom.element =
-  "queryAllByTestId";
-
-let queryAllByTestId = (id, element) => _queryAllByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findByTestId: (Dom.element, string) => Js.Promise.t(Dom.element) =
-  "findByTestId";
-
-let findByTestId = (id, element) => _findByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findAllByTestId:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
-  "findAllByTestId";
-
-let findAllByTestId = (id, element) => _findAllByTestId(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getByPlaceholderText: (Dom.element, string) => Dom.element =
-  "getByPlaceholderText";
-
-let getByPlaceholderText = (id, element) =>
-  _getByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getAllByPlaceholderText: (Dom.element, string) => Dom.element =
-  "getAllByPlaceholderText";
-
-let getAllByPlaceholderText = (id, element) =>
-  _getAllByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryByPlaceholderText: (Dom.element, string) => Dom.element =
-  "queryByPlaceholderText";
-
-let queryByPlaceholderText = (id, element) =>
-  _queryByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByPlaceholderText: (Dom.element, string) => Dom.element =
-  "queryAllByPlaceholderText";
-
-let queryAllByPlaceholderText = (id, element) =>
-  _queryAllByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findByPlaceholderText:
-  (Dom.element, string) => Js.Promise.t(Dom.element) =
-  "findByPlaceholderText";
-
-let findByPlaceholderText = (id, element) =>
-  _findByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findAllByPlaceholderText:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
-  "findAllByPlaceholderText";
-
-let findAllByPlaceholderText = (id, element) =>
-  _findAllByPlaceholderText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getByAltText: (Dom.element, string) => Dom.element = "getByAltText";
-
-let getByAltText = (id, element) => _getByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getAllByAltText: (Dom.element, string) => Dom.element =
-  "getAllByAltText";
-
-let getAllByAltText = (id, element) => _getAllByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryByAltText: (Dom.element, string) => Dom.element =
-  "queryByAltText";
-
-let queryByAltText = (id, element) => _queryByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByAltText: (Dom.element, string) => Dom.element =
-  "queryAllByAltText";
-
-let queryAllByAltText = (id, element) => _queryAllByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findByAltText: (Dom.element, string) => Js.Promise.t(Dom.element) =
-  "findByAltText";
-
-let findByAltText = (id, element) => _findByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findAllByAltText:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
-  "findAllByAltText";
-
-let findAllByAltText = (id, element) => _findAllByAltText(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getByDisplayValue: (Dom.element, string) => Dom.element =
-  "getByDisplayValue";
-
-let getByDisplayValue = (id, element) => _getByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getAllByDisplayValue: (Dom.element, string) => Dom.element =
-  "getAllByDisplayValue";
-
-let getAllByDisplayValue = (id, element) =>
-  _getAllByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryByDisplayValue: (Dom.element, string) => Dom.element =
-  "queryByDisplayValue";
-
-let queryByDisplayValue = (id, element) => _queryByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByDisplayValue: (Dom.element, string) => Dom.element =
-  "queryAllByDisplayValue";
-
-let queryAllByDisplayValue = (id, element) =>
-  _queryAllByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findByDisplayValue:
-  (Dom.element, string) => Js.Promise.t(Dom.element) =
-  "findByDisplayValue";
-
-let findByDisplayValue = (id, element) => _findByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _findAllByDisplayValue:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
-  "findAllByDisplayValue";
-
-let findAllByDisplayValue = (id, element) =>
-  _findAllByDisplayValue(element, id);
-
-[@bs.module "@testing-library/dom"]
-external _getByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Dom.element =
-  "getByText";
-
-let getByText = (~matcher, ~options=?, element) =>
-  _getByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
-
-[@bs.module "@testing-library/dom"]
-external _getAllByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Dom.element =
-  "getAllByText";
-
-let getAllByText = (~matcher, ~options=?, element) =>
-  _getAllByText(
-    element,
-    ~matcher,
-    ~options=Js.Undefined.fromOption(options),
-  );
-
-[@bs.module "@testing-library/dom"]
-external _queryByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Dom.element =
-  "queryByText";
-
-let queryByText = (~matcher, ~options=?, element) =>
-  _queryByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
-
-[@bs.module "@testing-library/dom"]
-external _queryAllByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Dom.element =
-  "queryAllByText";
-
-let queryAllByText = (~matcher, ~options=?, element) =>
-  _queryAllByText(
-    element,
-    ~matcher,
-    ~options=Js.Undefined.fromOption(options),
-  );
-
-[@bs.module "@testing-library/dom"]
-external _findByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Js.Promise.t(Dom.element) =
-  "findByText";
-
-let findByText = (~matcher, ~options=?, element) =>
-  _findByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
-
-[@bs.module "@testing-library/dom"]
-external _findAllByText:
-  (
-    Dom.element,
-    ~matcher: [@bs.unwrap] [
-                | `Str(string)
-                | `RegExp(Js.Re.t)
-                | `Func((string, Dom.element) => bool)
-              ],
-    ~options: Js.undefined(Query.options)
-  ) =>
-  Js.Promise.t(array(Dom.element)) =
-  "findAllByText";
-
-let findAllByText = (~matcher, ~options=?, element) =>
-  _findAllByText(
-    element,
-    ~matcher,
-    ~options=Js.Undefined.fromOption(options),
-  );
-
+/**
+ * ByLabelText
+ */
 [@bs.module "@testing-library/dom"]
 external _getByLabelText:
   (
@@ -457,6 +154,294 @@ let findAllByLabelText = (~matcher, ~options=?, element) =>
     ~options=Js.Undefined.fromOption(options),
   );
 
+/**
+ * ByPlaceholderText
+ */
+[@bs.module "@testing-library/dom"]
+external _getByPlaceholderText: (Dom.element, string) => Dom.element =
+  "getByPlaceholderText";
+
+let getByPlaceholderText = (id, element) =>
+  _getByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByPlaceholderText: (Dom.element, string) => Dom.element =
+  "getAllByPlaceholderText";
+
+let getAllByPlaceholderText = (id, element) =>
+  _getAllByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByPlaceholderText: (Dom.element, string) => Dom.element =
+  "queryByPlaceholderText";
+
+let queryByPlaceholderText = (id, element) =>
+  _queryByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByPlaceholderText: (Dom.element, string) => Dom.element =
+  "queryAllByPlaceholderText";
+
+let queryAllByPlaceholderText = (id, element) =>
+  _queryAllByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByPlaceholderText:
+  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByPlaceholderText";
+
+let findByPlaceholderText = (id, element) =>
+  _findByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByPlaceholderText:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByPlaceholderText";
+
+let findAllByPlaceholderText = (id, element) =>
+  _findAllByPlaceholderText(element, id);
+
+/**
+ * ByText
+ */
+[@bs.module "@testing-library/dom"]
+external _getByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "getByText";
+
+let getByText = (~matcher, ~options=?, element) =>
+  _getByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _getAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "getAllByText";
+
+let getAllByText = (~matcher, ~options=?, element) =>
+  _getAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _queryByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryByText";
+
+let queryByText = (~matcher, ~options=?, element) =>
+  _queryByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryAllByText";
+
+let queryAllByText = (~matcher, ~options=?, element) =>
+  _queryAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _findByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
+  "findByText";
+
+let findByText = (~matcher, ~options=?, element) =>
+  _findByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _findAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
+  "findAllByText";
+
+let findAllByText = (~matcher, ~options=?, element) =>
+  _findAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+/**
+ * ByAltText
+ */
+[@bs.module "@testing-library/dom"]
+external _getByAltText: (Dom.element, string) => Dom.element = "getByAltText";
+
+let getByAltText = (id, element) => _getByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByAltText: (Dom.element, string) => Dom.element =
+  "getAllByAltText";
+
+let getAllByAltText = (id, element) => _getAllByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByAltText: (Dom.element, string) => Dom.element =
+  "queryByAltText";
+
+let queryByAltText = (id, element) => _queryByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByAltText: (Dom.element, string) => Dom.element =
+  "queryAllByAltText";
+
+let queryAllByAltText = (id, element) => _queryAllByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByAltText: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByAltText";
+
+let findByAltText = (id, element) => _findByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByAltText:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByAltText";
+
+let findAllByAltText = (id, element) => _findAllByAltText(element, id);
+
+/**
+ * ByTitle
+ */
+[@bs.module "@testing-library/dom"]
+external _getByTitle: (Dom.element, string) => Dom.element = "getByTitle";
+
+let getByTitle = (id, element) => _getByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByTitle: (Dom.element, string) => Dom.element =
+  "getAllByTitle";
+
+let getAllByTitle = (id, element) => _getAllByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByTitle: (Dom.element, string) => Dom.element = "queryByTitle";
+
+let queryByTitle = (id, element) => _queryByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByTitle: (Dom.element, string) => Dom.element =
+  "queryAllByTitle";
+
+let queryAllByTitle = (id, element) => _queryAllByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByTitle: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByTitle";
+
+let findByTitle = (id, element) => _findByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByTitle:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByTitle";
+
+let findAllByTitle = (id, element) => _findAllByTitle(element, id);
+
+/**
+ * ByDisplayValue
+ */
+[@bs.module "@testing-library/dom"]
+external _getByDisplayValue: (Dom.element, string) => Dom.element =
+  "getByDisplayValue";
+
+let getByDisplayValue = (id, element) => _getByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByDisplayValue: (Dom.element, string) => Dom.element =
+  "getAllByDisplayValue";
+
+let getAllByDisplayValue = (id, element) =>
+  _getAllByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByDisplayValue: (Dom.element, string) => Dom.element =
+  "queryByDisplayValue";
+
+let queryByDisplayValue = (id, element) => _queryByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByDisplayValue: (Dom.element, string) => Dom.element =
+  "queryAllByDisplayValue";
+
+let queryAllByDisplayValue = (id, element) =>
+  _queryAllByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByDisplayValue:
+  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByDisplayValue";
+
+let findByDisplayValue = (id, element) => _findByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByDisplayValue:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByDisplayValue";
+
+let findAllByDisplayValue = (id, element) =>
+  _findAllByDisplayValue(element, id);
+
+/**
+ * ByRole
+ */
 [@bs.module "@testing-library/dom"]
 external _getByRole: (Dom.element, string) => Dom.element = "getByRole";
 
@@ -490,3 +475,42 @@ external _findAllByRole:
   "findAllByRole";
 
 let findAllByRole = (id, element) => _findAllByRole(element, id);
+
+/**
+ * ByTestId
+ */
+[@bs.module "@testing-library/dom"]
+external _getByTestId: (Dom.element, string) => Dom.element = "getByTestId";
+
+let getByTestId = (id, element) => _getByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByTestId: (Dom.element, string) => Dom.element =
+  "getAllByTestId";
+
+let getAllByTestId = (id, element) => _getAllByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByTestId: (Dom.element, string) => Dom.element =
+  "queryByTestId";
+
+let queryByTestId = (id, element) => _queryByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByTestId: (Dom.element, string) => Dom.element =
+  "queryAllByTestId";
+
+let queryAllByTestId = (id, element) => _queryAllByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByTestId: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByTestId";
+
+let findByTestId = (id, element) => _findByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByTestId:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByTestId";
+
+let findAllByTestId = (id, element) => _findAllByTestId(element, id);

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -121,7 +121,7 @@ module ByTestIdQuery = {
 };
 
 [@bs.module "@testing-library/dom"]
-external getNodeText: Dom.element => string = "";
+external getNodeText: Dom.element => string = "getNodeText";
 
 /**
  * ByLabelText

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -1,4 +1,23 @@
-module Query = {
+module ByLabelTextQuery = {
+  type options = {
+    .
+    "selector": Js.undefined(string),
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~selector: string=?,
+      ~exact: bool=?,
+      ~normalizer: string => string=?,
+      unit
+    ) =>
+    options =
+    "";
+};
+module ByTextQuery = {
   type options = {
     .
     "exact": Js.undefined(bool),
@@ -35,7 +54,7 @@ external _getByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Dom.element =
   "getByLabelText";
@@ -56,7 +75,7 @@ external _getAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Dom.element =
   "getAllByLabelText";
@@ -77,7 +96,7 @@ external _queryByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Dom.element =
   "queryByLabelText";
@@ -98,7 +117,7 @@ external _queryAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Dom.element =
   "queryAllByLabelText";
@@ -119,7 +138,7 @@ external _findByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
   "findByLabelText";
@@ -140,7 +159,7 @@ external _findAllByLabelText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
   "findAllByLabelText";
@@ -211,7 +230,7 @@ external _getByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Dom.element =
   "getByText";
@@ -228,7 +247,7 @@ external _getAllByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Dom.element =
   "getAllByText";
@@ -249,7 +268,7 @@ external _queryByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Dom.element =
   "queryByText";
@@ -266,7 +285,7 @@ external _queryAllByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Dom.element =
   "queryAllByText";
@@ -287,7 +306,7 @@ external _findByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Js.Promise.t(Dom.element) =
   "findByText";
@@ -304,7 +323,7 @@ external _findAllByText:
                 | `RegExp(Js.Re.t)
                 | `Func((string, Dom.element) => bool)
               ],
-    ~options: Js.undefined(Query.options)
+    ~options: Js.undefined(ByTextQuery.options)
   ) =>
   Js.Promise.t(array(Dom.element)) =
   "findAllByText";

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -31,9 +31,70 @@ external _getByTestId: (Dom.element, string) => Dom.element = "getByTestId";
 let getByTestId = (id, element) => _getByTestId(element, id);
 
 [@bs.module "@testing-library/dom"]
+external _getAllByTestId: (Dom.element, string) => Dom.element =
+  "getAllByTestId";
+
+let getAllByTestId = (id, element) => _getAllByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
 external _getByTitle: (Dom.element, string) => Dom.element = "getByTitle";
 
 let getByTitle = (id, element) => _getByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByTitle: (Dom.element, string) => Dom.element =
+  "getAllByTitle";
+
+let getAllByTitle = (id, element) => _getAllByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByTitle: (Dom.element, string) => Dom.element = "queryByTitle";
+
+let queryByTitle = (id, element) => _queryByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByTitle: (Dom.element, string) => Dom.element =
+  "queryAllByTitle";
+
+let queryAllByTitle = (id, element) => _queryAllByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByTitle: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByTitle";
+
+let findByTitle = (id, element) => _findByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByTitle:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByTitle";
+
+let findAllByTitle = (id, element) => _findAllByTitle(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByTestId: (Dom.element, string) => Dom.element =
+  "queryByTestId";
+
+let queryByTestId = (id, element) => _queryByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByTestId: (Dom.element, string) => Dom.element =
+  "queryAllByTestId";
+
+let queryAllByTestId = (id, element) => _queryAllByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByTestId: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByTestId";
+
+let findByTestId = (id, element) => _findByTestId(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByTestId:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByTestId";
+
+let findAllByTestId = (id, element) => _findAllByTestId(element, id);
 
 [@bs.module "@testing-library/dom"]
 external _getByPlaceholderText: (Dom.element, string) => Dom.element =
@@ -43,14 +104,118 @@ let getByPlaceholderText = (id, element) =>
   _getByPlaceholderText(element, id);
 
 [@bs.module "@testing-library/dom"]
+external _getAllByPlaceholderText: (Dom.element, string) => Dom.element =
+  "getAllByPlaceholderText";
+
+let getAllByPlaceholderText = (id, element) =>
+  _getAllByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByPlaceholderText: (Dom.element, string) => Dom.element =
+  "queryByPlaceholderText";
+
+let queryByPlaceholderText = (id, element) =>
+  _queryByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByPlaceholderText: (Dom.element, string) => Dom.element =
+  "queryAllByPlaceholderText";
+
+let queryAllByPlaceholderText = (id, element) =>
+  _queryAllByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByPlaceholderText:
+  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByPlaceholderText";
+
+let findByPlaceholderText = (id, element) =>
+  _findByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByPlaceholderText:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByPlaceholderText";
+
+let findAllByPlaceholderText = (id, element) =>
+  _findAllByPlaceholderText(element, id);
+
+[@bs.module "@testing-library/dom"]
 external _getByAltText: (Dom.element, string) => Dom.element = "getByAltText";
 
 let getByAltText = (id, element) => _getByAltText(element, id);
 
 [@bs.module "@testing-library/dom"]
-external _getByDisplayValue: (Dom.element, string) => Dom.element = "getByDisplayValue";
+external _getAllByAltText: (Dom.element, string) => Dom.element =
+  "getAllByAltText";
+
+let getAllByAltText = (id, element) => _getAllByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByAltText: (Dom.element, string) => Dom.element =
+  "queryByAltText";
+
+let queryByAltText = (id, element) => _queryByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByAltText: (Dom.element, string) => Dom.element =
+  "queryAllByAltText";
+
+let queryAllByAltText = (id, element) => _queryAllByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByAltText: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByAltText";
+
+let findByAltText = (id, element) => _findByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByAltText:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByAltText";
+
+let findAllByAltText = (id, element) => _findAllByAltText(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getByDisplayValue: (Dom.element, string) => Dom.element =
+  "getByDisplayValue";
 
 let getByDisplayValue = (id, element) => _getByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByDisplayValue: (Dom.element, string) => Dom.element =
+  "getAllByDisplayValue";
+
+let getAllByDisplayValue = (id, element) =>
+  _getAllByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByDisplayValue: (Dom.element, string) => Dom.element =
+  "queryByDisplayValue";
+
+let queryByDisplayValue = (id, element) => _queryByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByDisplayValue: (Dom.element, string) => Dom.element =
+  "queryAllByDisplayValue";
+
+let queryAllByDisplayValue = (id, element) =>
+  _queryAllByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByDisplayValue:
+  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByDisplayValue";
+
+let findByDisplayValue = (id, element) => _findByDisplayValue(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByDisplayValue:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByDisplayValue";
+
+let findAllByDisplayValue = (id, element) =>
+  _findAllByDisplayValue(element, id);
 
 [@bs.module "@testing-library/dom"]
 external _getByText:
@@ -68,6 +233,103 @@ external _getByText:
 
 let getByText = (~matcher, ~options=?, element) =>
   _getByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _getAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "getAllByText";
+
+let getAllByText = (~matcher, ~options=?, element) =>
+  _getAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _queryByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryByText";
+
+let queryByText = (~matcher, ~options=?, element) =>
+  _queryByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryAllByText";
+
+let queryAllByText = (~matcher, ~options=?, element) =>
+  _queryAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _findByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
+  "findByText";
+
+let findByText = (~matcher, ~options=?, element) =>
+  _findByText(element, ~matcher, ~options=Js.Undefined.fromOption(options));
+
+[@bs.module "@testing-library/dom"]
+external _findAllByText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
+  "findAllByText";
+
+let findAllByText = (~matcher, ~options=?, element) =>
+  _findAllByText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _getByLabelText:
@@ -89,3 +351,142 @@ let getByLabelText = (~matcher, ~options=?, element) =>
     ~matcher,
     ~options=Js.Undefined.fromOption(options),
   );
+
+[@bs.module "@testing-library/dom"]
+external _getAllByLabelText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "getAllByLabelText";
+
+let getAllByLabelText = (~matcher, ~options=?, element) =>
+  _getAllByLabelText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _queryByLabelText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryByLabelText";
+
+let queryByLabelText = (~matcher, ~options=?, element) =>
+  _queryByLabelText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByLabelText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Dom.element =
+  "queryAllByLabelText";
+
+let queryAllByLabelText = (~matcher, ~options=?, element) =>
+  _queryAllByLabelText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _findByLabelText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
+  "findByLabelText";
+
+let findByLabelText = (~matcher, ~options=?, element) =>
+  _findByLabelText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _findAllByLabelText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(Query.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
+  "findAllByLabelText";
+
+let findAllByLabelText = (~matcher, ~options=?, element) =>
+  _findAllByLabelText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
+
+[@bs.module "@testing-library/dom"]
+external _getByRole: (Dom.element, string) => Dom.element = "getByRole";
+
+let getByRole = (id, element) => _getByRole(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _getAllByRole: (Dom.element, string) => Dom.element = "getAllByRole";
+
+let getAllByRole = (id, element) => _getAllByRole(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryByRole: (Dom.element, string) => Dom.element = "queryByRole";
+
+let queryByRole = (id, element) => _queryByRole(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _queryAllByRole: (Dom.element, string) => Dom.element =
+  "queryAllByRole";
+
+let queryAllByRole = (id, element) => _queryAllByRole(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findByRole: (Dom.element, string) => Js.Promise.t(Dom.element) =
+  "findByRole";
+
+let findByRole = (id, element) => _findByRole(element, id);
+
+[@bs.module "@testing-library/dom"]
+external _findAllByRole:
+  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  "findAllByRole";
+
+let findAllByRole = (id, element) => _findAllByRole(element, id);

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -62,6 +62,18 @@ module ByAltTextQuery = {
     (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
     "";
 };
+module ByTitleQuery = {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";
@@ -574,39 +586,122 @@ let findAllByAltText = (~matcher, ~options=?, element) =>
  * ByTitle
  */
 [@bs.module "@testing-library/dom"]
-external _getByTitle: (Dom.element, string) => Dom.element = "getByTitle";
+external _getByTitle:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Dom.element =
+  "getByTitle";
 
-let getByTitle = (id, element) => _getByTitle(element, id);
+let getByTitle = (~matcher, ~options=?, element) =>
+  _getByTitle(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
-external _getAllByTitle: (Dom.element, string) => Dom.element =
+external _getAllByTitle:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Dom.element =
   "getAllByTitle";
 
-let getAllByTitle = (id, element) => _getAllByTitle(element, id);
+let getAllByTitle = (~matcher, ~options=?, element) =>
+  _getAllByTitle(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByTitle: (Dom.element, string) => Dom.element = "queryByTitle";
+external _queryByTitle:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Dom.element =
+  "queryByTitle";
 
-let queryByTitle = (id, element) => _queryByTitle(element, id);
+let queryByTitle = (~matcher, ~options=?, element) =>
+  _queryByTitle(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByTitle: (Dom.element, string) => Dom.element =
+external _queryAllByTitle:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByTitle";
 
-let queryAllByTitle = (id, element) => _queryAllByTitle(element, id);
+let queryAllByTitle = (~matcher, ~options=?, element) =>
+  _queryAllByTitle(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _findByTitle: (Dom.element, string) => Js.Promise.t(Dom.element) =
+external _findByTitle:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByTitle";
 
-let findByTitle = (id, element) => _findByTitle(element, id);
+let findByTitle = (~matcher, ~options=?, element) =>
+  _findByTitle(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
 external _findAllByTitle:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTitleQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByTitle";
 
-let findAllByTitle = (id, element) => _findAllByTitle(element, id);
+let findAllByTitle = (~matcher, ~options=?, element) =>
+  _findAllByTitle(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 /**
  * ByDisplayValue

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -50,6 +50,18 @@ module ByTextQuery = {
     options =
     "";
 };
+module ByAltTextQuery = {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 
 [@bs.module "@testing-library/dom"]
 external getNodeText: Dom.element => string = "";
@@ -433,40 +445,130 @@ let findAllByText = (~matcher, ~options=?, element) =>
  * ByAltText
  */
 [@bs.module "@testing-library/dom"]
-external _getByAltText: (Dom.element, string) => Dom.element = "getByAltText";
+external _getByAltText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Dom.element =
+  "getByAltText";
 
-let getByAltText = (id, element) => _getByAltText(element, id);
+let getByAltText = (~matcher, ~options=?, element) =>
+  _getByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _getAllByAltText: (Dom.element, string) => Dom.element =
+external _getAllByAltText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Dom.element =
   "getAllByAltText";
 
-let getAllByAltText = (id, element) => _getAllByAltText(element, id);
+let getAllByAltText = (~matcher, ~options=?, element) =>
+  _getAllByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByAltText: (Dom.element, string) => Dom.element =
+external _queryByAltText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Dom.element =
   "queryByAltText";
 
-let queryByAltText = (id, element) => _queryByAltText(element, id);
+let queryByAltText = (~matcher, ~options=?, element) =>
+  _queryByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByAltText: (Dom.element, string) => Dom.element =
+external _queryAllByAltText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByAltText";
 
-let queryAllByAltText = (id, element) => _queryAllByAltText(element, id);
+let queryAllByAltText = (~matcher, ~options=?, element) =>
+  _queryAllByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _findByAltText: (Dom.element, string) => Js.Promise.t(Dom.element) =
+external _findByAltText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByAltText";
 
-let findByAltText = (id, element) => _findByAltText(element, id);
+let findByAltText = (~matcher, ~options=?, element) =>
+  _findByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findAllByAltText:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByAltTextQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByAltText";
 
-let findAllByAltText = (id, element) => _findAllByAltText(element, id);
+let findAllByAltText = (~matcher, ~options=?, element) =>
+  _findAllByAltText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 /**
  * ByTitle

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -17,6 +17,18 @@ module ByLabelTextQuery = {
     options =
     "";
 };
+module ByPlaceholderTextQuery = {
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "normalizer": Js.undefined(string => string),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (~exact: bool=?, ~normalizer: string => string=?, unit) => options =
+    "";
+};
 module ByTextQuery = {
   type options = {
     .
@@ -175,48 +187,130 @@ let findAllByLabelText = (~matcher, ~options=?, element) =>
  * ByPlaceholderText
  */
 [@bs.module "@testing-library/dom"]
-external _getByPlaceholderText: (Dom.element, string) => Dom.element =
+external _getByPlaceholderText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Dom.element =
   "getByPlaceholderText";
 
-let getByPlaceholderText = (id, element) =>
-  _getByPlaceholderText(element, id);
+let getByPlaceholderText = (~matcher, ~options=?, element) =>
+  _getByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _getAllByPlaceholderText: (Dom.element, string) => Dom.element =
+external _getAllByPlaceholderText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Dom.element =
   "getAllByPlaceholderText";
 
-let getAllByPlaceholderText = (id, element) =>
-  _getAllByPlaceholderText(element, id);
+let getAllByPlaceholderText = (~matcher, ~options=?, element) =>
+  _getAllByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByPlaceholderText: (Dom.element, string) => Dom.element =
+external _queryByPlaceholderText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Dom.element =
   "queryByPlaceholderText";
 
-let queryByPlaceholderText = (id, element) =>
-  _queryByPlaceholderText(element, id);
+let queryByPlaceholderText = (~matcher, ~options=?, element) =>
+  _queryByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByPlaceholderText: (Dom.element, string) => Dom.element =
+external _queryAllByPlaceholderText:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByPlaceholderText";
 
-let queryAllByPlaceholderText = (id, element) =>
-  _queryAllByPlaceholderText(element, id);
+let queryAllByPlaceholderText = (~matcher, ~options=?, element) =>
+  _queryAllByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findByPlaceholderText:
-  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByPlaceholderText";
 
-let findByPlaceholderText = (id, element) =>
-  _findByPlaceholderText(element, id);
+let findByPlaceholderText = (~matcher, ~options=?, element) =>
+  _findByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findAllByPlaceholderText:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Str(string)
+                | `RegExp(Js.Re.t)
+                | `Func((string, Dom.element) => bool)
+              ],
+    ~options: Js.undefined(ByPlaceholderTextQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByPlaceholderText";
 
-let findAllByPlaceholderText = (id, element) =>
-  _findAllByPlaceholderText(element, id);
+let findAllByPlaceholderText = (~matcher, ~options=?, element) =>
+  _findAllByPlaceholderText(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 /**
  * ByText

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -87,70 +87,25 @@ module ByDisplayValueQuery = {
     "";
 };
 module ByRoleQuery = {
-  module NameStr = {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined(string),
-      "normalizer": Js.undefined(string => string),
-    };
-
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: string=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
+  type options = {
+    .
+    "exact": Js.undefined(bool),
+    "hidden": Js.undefined(bool),
+    "name": Js.undefined(string),
+    "normalizer": Js.undefined(string => string),
   };
 
-  module NameRegExp = {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined(Js.Re.t),
-      "normalizer": Js.undefined(string => string),
-    };
-
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: Js.Re.t=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
-  };
-  module NameFunc = {
-    type options = {
-      .
-      "exact": Js.undefined(bool),
-      "hidden": Js.undefined(bool),
-      "name": Js.undefined((string, Dom.element) => bool),
-      "normalizer": Js.undefined(string => string),
-    };
-
-    [@bs.obj]
-    external makeOptions:
-      (
-        ~exact: bool=?,
-        ~hidden: bool=?,
-        ~name: (string, Dom.element) => bool=?,
-        ~normalizer: string => string=?,
-        unit
-      ) =>
-      options =
-      "";
-  };
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~exact: bool=?,
+      ~hidden: bool=?,
+      ~name: string=?,
+      ~normalizer: string => string=?,
+      unit
+    ) =>
+    options =
+    "";
 };
 module ByTestIdQuery = {
   type options = {
@@ -797,118 +752,369 @@ let findAllByTitle = (~matcher, ~options=?, element) =>
  * ByDisplayValue
  */
 [@bs.module "@testing-library/dom"]
-external _getByDisplayValue: (Dom.element, string) => Dom.element =
+external _getByDisplayValue:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Dom.element =
   "getByDisplayValue";
 
-let getByDisplayValue = (id, element) => _getByDisplayValue(element, id);
+let getByDisplayValue = (~matcher, ~options=?, element) =>
+  _getByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _getAllByDisplayValue: (Dom.element, string) => Dom.element =
+external _getAllByDisplayValue:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Dom.element =
   "getAllByDisplayValue";
 
-let getAllByDisplayValue = (id, element) =>
-  _getAllByDisplayValue(element, id);
+let getAllByDisplayValue = (~matcher, ~options=?, element) =>
+  _getAllByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByDisplayValue: (Dom.element, string) => Dom.element =
+external _queryByDisplayValue:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Dom.element =
   "queryByDisplayValue";
 
-let queryByDisplayValue = (id, element) => _queryByDisplayValue(element, id);
+let queryByDisplayValue = (~matcher, ~options=?, element) =>
+  _queryByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByDisplayValue: (Dom.element, string) => Dom.element =
+external _queryAllByDisplayValue:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByDisplayValue";
 
-let queryAllByDisplayValue = (id, element) =>
-  _queryAllByDisplayValue(element, id);
+let queryAllByDisplayValue = (~matcher, ~options=?, element) =>
+  _queryAllByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findByDisplayValue:
-  (Dom.element, string) => Js.Promise.t(Dom.element) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByDisplayValue";
 
-let findByDisplayValue = (id, element) => _findByDisplayValue(element, id);
+let findByDisplayValue = (~matcher, ~options=?, element) =>
+  _findByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findAllByDisplayValue:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByDisplayValueQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByDisplayValue";
 
-let findAllByDisplayValue = (id, element) =>
-  _findAllByDisplayValue(element, id);
+let findAllByDisplayValue = (~matcher, ~options=?, element) =>
+  _findAllByDisplayValue(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 /**
  * ByRole
  */
 [@bs.module "@testing-library/dom"]
-external _getByRole: (Dom.element, string) => Dom.element = "getByRole";
+external _getByRole:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Dom.element =
+  "getByRole";
 
-let getByRole = (id, element) => _getByRole(element, id);
+let getByRole = (~matcher, ~options=?, element) =>
+  _getByRole(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
-external _getAllByRole: (Dom.element, string) => Dom.element = "getAllByRole";
+external _getAllByRole:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Dom.element =
+  "getAllByRole";
 
-let getAllByRole = (id, element) => _getAllByRole(element, id);
+let getAllByRole = (~matcher, ~options=?, element) =>
+  _getAllByRole(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByRole: (Dom.element, string) => Dom.element = "queryByRole";
+external _queryByRole:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Dom.element =
+  "queryByRole";
 
-let queryByRole = (id, element) => _queryByRole(element, id);
+let queryByRole = (~matcher, ~options=?, element) =>
+  _queryByRole(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByRole: (Dom.element, string) => Dom.element =
+external _queryAllByRole:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByRole";
 
-let queryAllByRole = (id, element) => _queryAllByRole(element, id);
+let queryAllByRole = (~matcher, ~options=?, element) =>
+  _queryAllByRole(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _findByRole: (Dom.element, string) => Js.Promise.t(Dom.element) =
+external _findByRole:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByRole";
 
-let findByRole = (id, element) => _findByRole(element, id);
+let findByRole = (~matcher, ~options=?, element) =>
+  _findByRole(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
 external _findAllByRole:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByRoleQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByRole";
 
-let findAllByRole = (id, element) => _findAllByRole(element, id);
+let findAllByRole = (~matcher, ~options=?, element) =>
+  _findAllByRole(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 /**
  * ByTestId
  */
 [@bs.module "@testing-library/dom"]
-external _getByTestId: (Dom.element, string) => Dom.element = "getByTestId";
+external _getByTestId:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Dom.element =
+  "getByTestId";
 
-let getByTestId = (id, element) => _getByTestId(element, id);
+let getByTestId = (~matcher, ~options=?, element) =>
+  _getByTestId(element, ~matcher, ~options=Js.Undefined.fromOption(options));
 
 [@bs.module "@testing-library/dom"]
-external _getAllByTestId: (Dom.element, string) => Dom.element =
+external _getAllByTestId:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Dom.element =
   "getAllByTestId";
 
-let getAllByTestId = (id, element) => _getAllByTestId(element, id);
+let getAllByTestId = (~matcher, ~options=?, element) =>
+  _getAllByTestId(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryByTestId: (Dom.element, string) => Dom.element =
+external _queryByTestId:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Dom.element =
   "queryByTestId";
 
-let queryByTestId = (id, element) => _queryByTestId(element, id);
+let queryByTestId = (~matcher, ~options=?, element) =>
+  _queryByTestId(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _queryAllByTestId: (Dom.element, string) => Dom.element =
+external _queryAllByTestId:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Dom.element =
   "queryAllByTestId";
 
-let queryAllByTestId = (id, element) => _queryAllByTestId(element, id);
+let queryAllByTestId = (~matcher, ~options=?, element) =>
+  _queryAllByTestId(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
-external _findByTestId: (Dom.element, string) => Js.Promise.t(Dom.element) =
+external _findByTestId:
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Js.Promise.t(Dom.element) =
   "findByTestId";
 
-let findByTestId = (id, element) => _findByTestId(element, id);
+let findByTestId = (~matcher, ~options=?, element) =>
+  _findByTestId(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );
 
 [@bs.module "@testing-library/dom"]
 external _findAllByTestId:
-  (Dom.element, string) => Js.Promise.t(array(Dom.element)) =
+  (
+    Dom.element,
+    ~matcher: [@bs.unwrap] [
+                | `Func((string, Dom.element) => bool)
+                | `RegExp(Js.Re.t)
+                | `Str(string)
+              ],
+    ~options: Js.undefined(ByTestIdQuery.options)
+  ) =>
+  Js.Promise.t(array(Dom.element)) =
   "findAllByTestId";
 
-let findAllByTestId = (id, element) => _findAllByTestId(element, id);
+let findAllByTestId = (~matcher, ~options=?, element) =>
+  _findAllByTestId(
+    element,
+    ~matcher,
+    ~options=Js.Undefined.fromOption(options),
+  );

--- a/src/DomTestingLibrary__Utils.re
+++ b/src/DomTestingLibrary__Utils.re
@@ -1,17 +1,5 @@
-module Wait = {
+module MutationObserver = {
   type options = {
-    .
-    "interval": Js.undefined(int),
-    "timeout": Js.undefined(int),
-  };
-
-  [@bs.obj]
-  external makeOptions: (~interval: int=?, ~timeout: int=?, unit) => options =
-    "";
-};
-
-module WaitForElement = {
-  type mutationObserverOptions = {
     .
     "attributeFilter": Js.undefined(array(string)),
     "attributeOldValue": Js.undefined(bool),
@@ -20,6 +8,45 @@ module WaitForElement = {
     "characterDataOldValue": Js.undefined(bool),
     "subtree": Js.undefined(bool),
   };
+
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~attributeFilter: array(string)=?,
+      ~attributeOldValue: bool=?,
+      ~attributes: bool=?,
+      ~characterData: bool=?,
+      ~characterDataOldValue: bool=?,
+      ~subtree: bool=?,
+      unit
+    ) =>
+    options =
+    "";
+};
+
+module WaitFor = {
+  type options = {
+    .
+    "container": Js.undefined(Dom.element),
+    "interval": Js.undefined(int),
+    "timeout": Js.undefined(int),
+    "mutationObserverOptions": Js.undefined(MutationObserver.options),
+  };
+
+  [@bs.obj]
+  external makeOptions:
+    (
+      ~container: Dom.element=?,
+      ~interval: int=?,
+      ~timeout: int=?,
+      ~mutationObserverOptions: MutationObserver.options=?,
+      unit
+    ) =>
+    options =
+    "";
+};
+
+module WaitForElement = {
   type options = {
     .
     "container": Js.undefined(Dom.element),
@@ -30,36 +57,22 @@ module WaitForElement = {
   external makeOptions:
     (
       ~container: Dom.element=?,
-      ~mutationObserverInit: mutationObserverOptions=?,
+      ~mutationObserverInit: MutationObserver.options=?,
       ~timeout: int=?,
       unit
     ) =>
     options =
     "";
-
-  [@bs.obj]
-  external makeMutationObserverOptions:
-    (
-      ~attributeFilter: array(string)=?,
-      ~attributeOldValue: bool=?,
-      ~attributes: bool=?,
-      ~characterData: bool=?,
-      ~characterDataOldValue: bool=?,
-      ~subtree: bool=?,
-      unit
-    ) =>
-    mutationObserverOptions =
-    "";
 };
 
 [@bs.module "@testing-library/dom"]
-external _wait:
-  (Js.undefined(unit => unit), Js.undefined(Wait.options)) =>
+external _waitFor:
+  (Js.undefined(unit => unit), Js.undefined(WaitFor.options)) =>
   Js.Promise.t('a) =
-  "wait";
+  "waitFor";
 
-let wait = (~callback=?, ~options=?, ()) =>
-  _wait(
+let waitFor = (~callback=?, ~options=?, ()) =>
+  _waitFor(
     Js.Undefined.fromOption(callback),
     Js.Undefined.fromOption(options),
   );

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -4,6 +4,7 @@ open Webapi.Dom;
 open Webapi.Dom.Element;
 
 [@bs.get] external tagName: Dom.element => string = "";
+[@bs.get] external name: Dom.element => string = "";
 
 [@bs.val] external setTimeout: (unit => unit, int) => float = "setTimeout";
 
@@ -41,14 +42,12 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("configure works", () => {
-    afterAll(() => {
+    afterAll(() =>
       configure(
         ~update=
-          `Object({
-            "testIdAttribute": Js.Undefined.return("data-testid"),
-          }),
-      );
-    });
+          `Object({"testIdAttribute": Js.Undefined.return("data-testid")}),
+      )
+    );
 
     test("using an object", () => {
       configure(
@@ -233,45 +232,155 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("ByPlaceholderText", () => {
-    test("get works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> getByPlaceholderText("Enter something")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> getByPlaceholderText(~matcher=`Str("Enter something"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> getAllByPlaceholderText("Enter something")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> getAllByPlaceholderText(~matcher=`Str("Enter something"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> queryByPlaceholderText("Enter something")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> queryByPlaceholderText(~matcher=`Str("Enter something"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> queryAllByPlaceholderText("Enter something")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> queryAllByPlaceholderText(~matcher=`Str("Enter something"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> findByPlaceholderText("Enter something")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> findByPlaceholderText(~matcher=`Str("Enter something"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<input type="text" placeholder="Enter something" />|})
-      |> findAllByPlaceholderText("Enter something")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> findAllByPlaceholderText(~matcher=`Str("Enter something"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> getByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> getAllByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> queryByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> queryAllByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> findByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<input type="text" placeholder="Enter something" />|})
+        |> findAllByPlaceholderText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("function matcher", () => {
+      test("get works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> getByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> getAllByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> queryByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> queryAllByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> findByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render(
+          {|<input type="text" name="my-input" placeholder="Enter something" />|},
+        )
+        |> findAllByPlaceholderText(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   describe("ByText", () => {

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -524,45 +524,143 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("ByAltText", () => {
-    test("get works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> getByAltText("Alt text")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> getByAltText(~matcher=`Str("Alt text"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> getAllByAltText("Alt text")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> getAllByAltText(~matcher=`Str("Alt text"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> queryByAltText("Alt text")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> queryByAltText(~matcher=`Str("Alt text"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> queryAllByAltText("Alt text")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> queryAllByAltText(~matcher=`Str("Alt text"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> findByAltText("Alt text")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> findByAltText(~matcher=`Str("Alt text"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<img src="" alt="Alt text" />|})
-      |> findAllByAltText("Alt text")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> findAllByAltText(~matcher=`Str("Alt text"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> getByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> getAllByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> queryByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> queryAllByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> findByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<img src="" alt="Alt text" />|})
+        |> findAllByAltText(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> getByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> getAllByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> queryByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> queryAllByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> findByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<img name="my-img" src="" alt="Alt text" />|})
+        |> findAllByAltText(
+             ~matcher=`Func((_text, node) => node |> name === "my-img"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   describe("ByTitle", () => {

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -1,3 +1,4 @@
+open Js.Promise;
 open Jest;
 open Webapi.Dom;
 open Webapi.Dom.Element;
@@ -39,21 +40,6 @@ describe("DomTestingLibrary", () => {
     );
   });
 
-  test("getNodeText works", () =>
-    render({|<b title="greeting">Hello,</b>|})
-    |> getByTitle("greeting")
-    |> getNodeText
-    |> expect
-    |> toMatchSnapshot
-  );
-
-  test("getByTestId works", () =>
-    render({|<p data-testid="world"> World!</p>|})
-    |> getByTestId("world")
-    |> expect
-    |> toMatchSnapshot
-  );
-
   describe("configure works", () => {
     test("using an object", () => {
       configure(
@@ -85,112 +71,614 @@ describe("DomTestingLibrary", () => {
     });
   });
 
-  test("getByPlaceholderText works", () =>
-    render({|<input type="text" placeholder="Enter something" />|})
-    |> getByPlaceholderText("Enter something")
-    |> expect
-    |> toMatchSnapshot
-  );
+  describe("ByLabelText", () => {
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> getByLabelText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-  test("getByAltText works", () =>
-    render({|<img src="" alt="Alt text" />|})
-    |> getByAltText("Alt text")
-    |> expect
-    |> toMatchSnapshot
-  );
+      test("getAll works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> getAllByLabelText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-  test("getByTitle works", () =>
+      test("query works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> queryByLabelText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> queryAllByLabelText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> findByLabelText(~matcher=`Str("Hello,"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<label>Hello, <input /></label>|})
+        |> findAllByLabelText(~matcher=`Str("Hello,"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> getByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> getAllByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> queryByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> queryAllByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> findByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render(
+          {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
+        )
+        |> findAllByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> getByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> getAllByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> queryByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> queryAllByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> findByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<p aria-label="message">World!</p>|})
+        |> findAllByLabelText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+  });
+
+  describe("ByPlaceholderText", () => {
+    test("get works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> getByPlaceholderText("Enter something")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> getAllByPlaceholderText("Enter something")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> queryByPlaceholderText("Enter something")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> queryAllByPlaceholderText("Enter something")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> findByPlaceholderText("Enter something")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<input type="text" placeholder="Enter something" />|})
+      |> findAllByPlaceholderText("Enter something")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  describe("ByText", () => {
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getByText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getAllByText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryByText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryAllByText(~matcher=`Str("Hello,"))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findByText(~matcher=`Str("Hello,"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findAllByText(~matcher=`Str("Hello,"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getAllByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryAllByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findAllByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getAllByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryAllByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findAllByText(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+  });
+
+  describe("ByAltText", () => {
+    test("get works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> getByAltText("Alt text")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> getAllByAltText("Alt text")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> queryByAltText("Alt text")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> queryAllByAltText("Alt text")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> findByAltText("Alt text")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<img src="" alt="Alt text" />|})
+      |> findAllByAltText("Alt text")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  describe("ByTitle", () => {
+    test("get works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> getByTitle("greeting")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> getAllByTitle("greeting")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> queryByTitle("greeting")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> queryAllByTitle("greeting")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> findByTitle("greeting")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<b title="greeting">Hello,</b>|})
+      |> findAllByTitle("greeting")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  describe("ByDisplayValue", () => {
+    test("get works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> getByDisplayValue("Some value")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> getAllByDisplayValue("Some value")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> queryByDisplayValue("Some value")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> queryAllByDisplayValue("Some value")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> findByDisplayValue("Some value")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<input type="text" value="Some value" />|})
+      |> findAllByDisplayValue("Some value")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  describe("ByRole", () => {
+    test("get works", () =>
+      render({|<button>World!</button>|})
+      |> getByRole("button")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<button>World!</button>|})
+      |> getAllByRole("button")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<button>World!</button>|})
+      |> queryByRole("button")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<button>World!</button>|})
+      |> queryAllByRole("button")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<button>World!</button>|})
+      |> findByRole("button")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<button>World!</button>|})
+      |> findAllByRole("button")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  describe("ByTestId", () => {
+    test("get works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> getByTestId("world")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("getAll works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> getAllByTestId("world")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("query works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> queryByTestId("world")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    test("queryAll works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> queryAllByTestId("world")
+      |> expect
+      |> toMatchSnapshot
+    );
+
+    testPromise("find works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> findByTestId("world")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+
+    testPromise("findAll works", () =>
+      render({|<p data-testid="world">World!</p>|})
+      |> findAllByTestId("world")
+      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+    );
+  });
+
+  test("getNodeText works", () =>
     render({|<b title="greeting">Hello,</b>|})
     |> getByTitle("greeting")
+    |> getNodeText
     |> expect
     |> toMatchSnapshot
   );
 
-  test("getByDisplayValue works", () =>
-    render({|<input type="text" value="Some value" />|})
-    |> getByDisplayValue("Some value")
-    |> expect
-    |> toMatchSnapshot
-  );
-
-  describe("getByText", () => {
-    test("works with string matcher", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> getByText(~matcher=`Str("Hello,"))
-      |> expect
-      |> toMatchSnapshot
-    );
-
-    test("works with regex matcher", () =>
-      render({|<p data-testid="world"> World!</p>|})
-      |> getByText(~matcher=`RegExp([%bs.re "/\\w!/"]))
-      |> expect
-      |> toMatchSnapshot
-    );
-
-    test("works with function matcher", () =>
-      render({|<p data-testid="world"> World!</p>|})
-      |> getByText(
-           ~matcher=`Func((_text, node) => node |> tagName === "P"),
-         )
-      |> expect
-      |> toMatchSnapshot
-    );
-  });
-
-  describe("getByLabelText", () => {
-    test("works with string matcher", () =>
-      render({|<label>Hello, <input /></label>|})
-      |> getByLabelText(~matcher=`Str("Hello,"))
-      |> expect
-      |> toMatchSnapshot
-    );
-
-    test("works with regex matcher", () =>
-      render(
-        {|<section aria-labelledby="section-one-header"><h3 id="section-one-header">Section One!</h3><p>some content</p></section>|},
-      )
-      |> getByLabelText(~matcher=`RegExp([%bs.re "/\\w!/"]))
-      |> expect
-      |> toMatchSnapshot
-    );
-
-    test("works with function matcher", () =>
-      render({|<p aria-label="message"> World!</p>|})
-      |> getByLabelText(
-           ~matcher=`Func((_text, node) => node |> tagName === "P"),
-         )
-      |> expect
-      |> toMatchSnapshot
-    );
-  });
-
-  describe("wait", () => {
+  describe("waitFor", () => {
     testPromise("works", () => {
       let number = ref(10);
       let timeout = Js.Math.floor(Js.Math.random() *. 300.);
       let _ = setTimeout(() => number := 100, timeout);
       let callback = () => assert(number^ == 100);
 
-      wait(~callback, ()) |> Js.Promise.then_(_ => Js.Promise.resolve(pass));
+      waitFor(~callback, ())
+      |> Js.Promise.then_(_ => Js.Promise.resolve(pass));
+    });
+
+    testPromise("supports container option", () => {
+      let number = ref(0);
+      let timeout = Js.Math.floor(Js.Math.random() *. 300.);
+      let _ = setTimeout(() => number := 100, timeout);
+      let callback = () => assert(number^ == 10);
+      let body =
+        document
+        |> Document.asHtmlDocument
+        |> Belt.Option.flatMap(_, HtmlDocument.body);
+      let options = WaitFor.makeOptions(~container=?body, ());
+
+      waitFor(~callback, ~options, ())
+      |> Js.Promise.catch(_ => Js.Promise.resolve(pass));
     });
 
     testPromise("supports timeout option", () => {
       let number = ref(10);
       let _ = setTimeout(() => number := 100, 1000);
       let callback = () => assert(number^ == 100);
-      let options = Wait.makeOptions(~timeout=500, ());
+      let options = WaitFor.makeOptions(~timeout=500, ());
 
-      wait(~callback, ~options, ())
+      waitFor(~callback, ~options, ())
       |> Js.Promise.catch(_ => Js.Promise.resolve(pass));
     });
 
     testPromise("supports interval option", () => {
       let number = ref(0);
       let callback = () => assert(number^ == 10);
-      let options = Wait.makeOptions(~interval=10, ~timeout=45, ());
+      let options = WaitFor.makeOptions(~interval=10, ~timeout=45, ());
 
-      wait(~callback, ~options, ())
+      waitFor(~callback, ~options, ())
+      |> Js.Promise.catch(_ => Js.Promise.resolve(pass));
+    });
+
+    testPromise("supports mutationObserverOptions option", () => {
+      let number = ref(0);
+      let callback = () => assert(number^ == 10);
+      let options =
+        WaitFor.makeOptions(
+          ~mutationObserverOptions=
+            DomTestingLibrary.MutationObserver.makeOptions(),
+          (),
+        );
+
+      waitFor(~callback, ~options, ())
       |> Js.Promise.catch(_ => Js.Promise.resolve(pass));
     });
   });

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -41,6 +41,15 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("configure works", () => {
+    afterAll(() => {
+      configure(
+        ~update=
+          `Object({
+            "testIdAttribute": Js.Undefined.return("data-testid"),
+          }),
+      );
+    });
+
     test("using an object", () => {
       configure(
         ~update=

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -57,7 +57,7 @@ describe("DomTestingLibrary", () => {
           }),
       );
       render({|<p data-custom-test-id="world"> World!</p>|})
-      |> getByTestId("world")
+      |> getByTestId(~matcher=`Str("world"))
       |> expect
       |> toMatchSnapshot;
     });
@@ -73,7 +73,7 @@ describe("DomTestingLibrary", () => {
           ),
       );
       render({|<p data-custom-test-id="world"> World!</p>|})
-      |> getByTestId("world")
+      |> getByTestId(~matcher=`Str("world"))
       |> expect
       |> toMatchSnapshot;
     });
@@ -804,129 +804,418 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("ByDisplayValue", () => {
-    test("get works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> getByDisplayValue("Some value")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> getByDisplayValue(~matcher=`Str("Some value"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> getAllByDisplayValue("Some value")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> getAllByDisplayValue(~matcher=`Str("Some value"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> queryByDisplayValue("Some value")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> queryByDisplayValue(~matcher=`Str("Some value"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> queryAllByDisplayValue("Some value")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> queryAllByDisplayValue(~matcher=`Str("Some value"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> findByDisplayValue("Some value")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> findByDisplayValue(~matcher=`Str("Some value"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<input type="text" value="Some value" />|})
-      |> findAllByDisplayValue("Some value")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> findAllByDisplayValue(~matcher=`Str("Some value"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> getByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> getAllByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> queryByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> queryAllByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> findByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<input type="text" value="Some value" />|})
+        |> findAllByDisplayValue(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> getByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> getAllByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> queryByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> queryAllByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> findByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<input name="my-input" type="text" value="Some value" />|})
+        |> findAllByDisplayValue(
+             ~matcher=`Func((_text, node) => node |> name === "my-input"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   describe("ByRole", () => {
-    test("get works", () =>
-      render({|<button>World!</button>|})
-      |> getByRole("button")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<button>World!</button>|})
+        |> getByRole(~matcher=`Str("button"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<button>World!</button>|})
-      |> getAllByRole("button")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<button>World!</button>|})
+        |> getAllByRole(~matcher=`Str("button"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<button>World!</button>|})
-      |> queryByRole("button")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<button>World!</button>|})
+        |> queryByRole(~matcher=`Str("button"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<button>World!</button>|})
-      |> queryAllByRole("button")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<button>World!</button>|})
+        |> queryAllByRole(~matcher=`Str("button"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<button>World!</button>|})
-      |> findByRole("button")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<button>World!</button>|})
+        |> findByRole(~matcher=`Str("button"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<button>World!</button>|})
-      |> findAllByRole("button")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<button>World!</button>|})
+        |> findAllByRole(~matcher=`Str("button"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<button>World!</button>|})
+        |> getByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<button>World!</button>|})
+        |> getAllByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<button>World!</button>|})
+        |> queryByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<button>World!</button>|})
+        |> queryAllByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<button>World!</button>|})
+        |> findByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<button>World!</button>|})
+        |> findAllByRole(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<button>World!</button>|})
+        |> getByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<button>World!</button>|})
+        |> getAllByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<button>World!</button>|})
+        |> queryByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<button>World!</button>|})
+        |> queryAllByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<button>World!</button>|})
+        |> findByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<button>World!</button>|})
+        |> findAllByRole(
+             ~matcher=`Func((_text, node) => node |> tagName === "BUTTON"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   describe("ByTestId", () => {
-    test("get works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> getByTestId("world")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getByTestId(~matcher=`Str("world"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> getAllByTestId("world")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getAllByTestId(~matcher=`Str("world"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> queryByTestId("world")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryByTestId(~matcher=`Str("world"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> queryAllByTestId("world")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryAllByTestId(~matcher=`Str("world"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> findByTestId("world")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findByTestId(~matcher=`Str("world"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<p data-testid="world">World!</p>|})
-      |> findAllByTestId("world")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findAllByTestId(~matcher=`Str("world"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+    describe("regex matcher", () => {
+      test("get works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getAllByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryAllByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findAllByTestId(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> getAllByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> queryAllByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<p data-testid="world">World!</p>|})
+        |> findAllByTestId(
+             ~matcher=`Func((_text, node) => node |> tagName === "P"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   test("getNodeText works", () =>

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -664,45 +664,143 @@ describe("DomTestingLibrary", () => {
   });
 
   describe("ByTitle", () => {
-    test("get works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> getByTitle("greeting")
-      |> expect
-      |> toMatchSnapshot
-    );
+    describe("string matcher", () => {
+      test("get works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getByTitle(~matcher=`Str("greeting"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("getAll works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> getAllByTitle("greeting")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("getAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getAllByTitle(~matcher=`Str("greeting"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("query works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> queryByTitle("greeting")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("query works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryByTitle(~matcher=`Str("greeting"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    test("queryAll works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> queryAllByTitle("greeting")
-      |> expect
-      |> toMatchSnapshot
-    );
+      test("queryAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryAllByTitle(~matcher=`Str("greeting"))
+        |> expect
+        |> toMatchSnapshot
+      );
 
-    testPromise("find works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> findByTitle("greeting")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("find works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findByTitle(~matcher=`Str("greeting"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
 
-    testPromise("findAll works", () =>
-      render({|<b title="greeting">Hello,</b>|})
-      |> findAllByTitle("greeting")
-      |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
-    );
+      testPromise("findAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findAllByTitle(~matcher=`Str("greeting"))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("regexp matcher", () => {
+      test("get works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getAllByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryAllByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findAllByTitle(~matcher=`RegExp([%bs.re "/\\w+/"]))
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
+
+    describe("function matcher", () => {
+      test("get works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("getAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> getAllByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("query works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      test("queryAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> queryAllByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> expect
+        |> toMatchSnapshot
+      );
+
+      testPromise("find works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+
+      testPromise("findAll works", () =>
+        render({|<b title="greeting">Hello,</b>|})
+        |> findAllByTitle(
+             ~matcher=`Func((_text, node) => node |> tagName === "B"),
+           )
+        |> then_(actual => actual |> expect |> toMatchSnapshot |> resolve)
+      );
+    });
   });
 
   describe("ByDisplayValue", () => {
@@ -833,7 +931,7 @@ describe("DomTestingLibrary", () => {
 
   test("getNodeText works", () =>
     render({|<b title="greeting">Hello,</b>|})
-    |> getByTitle("greeting")
+    |> getByTitle(~matcher=`Str("greeting"))
     |> getNodeText
     |> expect
     |> toMatchSnapshot

--- a/src/__tests__/DomTestingLibrary_test.re
+++ b/src/__tests__/DomTestingLibrary_test.re
@@ -3,8 +3,8 @@ open Jest;
 open Webapi.Dom;
 open Webapi.Dom.Element;
 
-[@bs.get] external tagName: Dom.element => string = "";
-[@bs.get] external name: Dom.element => string = "";
+[@bs.get] external tagName: Dom.element => string = "tagName";
+[@bs.get] external name: Dom.element => string = "name";
 
 [@bs.val] external setTimeout: (unit => unit, int) => float = "setTimeout";
 

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -1,13 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DomTestingLibrary ByAltText find works 1`] = `
+exports[`DomTestingLibrary ByAltText function matcher find works 1`] = `
+<img
+  alt="Alt text"
+  name="my-img"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText function matcher findAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    name="my-img"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText function matcher get works 1`] = `
+<img
+  alt="Alt text"
+  name="my-img"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText function matcher getAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    name="my-img"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText function matcher query works 1`] = `
+<img
+  alt="Alt text"
+  name="my-img"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText function matcher queryAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    name="my-img"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText regex matcher find works 1`] = `
 <img
   alt="Alt text"
   src=""
 />
 `;
 
-exports[`DomTestingLibrary ByAltText findAll works 1`] = `
+exports[`DomTestingLibrary ByAltText regex matcher findAll works 1`] = `
 Array [
   <img
     alt="Alt text"
@@ -16,14 +70,14 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByAltText get works 1`] = `
+exports[`DomTestingLibrary ByAltText regex matcher get works 1`] = `
 <img
   alt="Alt text"
   src=""
 />
 `;
 
-exports[`DomTestingLibrary ByAltText getAll works 1`] = `
+exports[`DomTestingLibrary ByAltText regex matcher getAll works 1`] = `
 Array [
   <img
     alt="Alt text"
@@ -32,14 +86,62 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByAltText query works 1`] = `
+exports[`DomTestingLibrary ByAltText regex matcher query works 1`] = `
 <img
   alt="Alt text"
   src=""
 />
 `;
 
-exports[`DomTestingLibrary ByAltText queryAll works 1`] = `
+exports[`DomTestingLibrary ByAltText regex matcher queryAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher find works 1`] = `
+<img
+  alt="Alt text"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher findAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher get works 1`] = `
+<img
+  alt="Alt text"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher getAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher query works 1`] = `
+<img
+  alt="Alt text"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText string matcher queryAll works 1`] = `
 Array [
   <img
     alt="Alt text"

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -780,7 +780,7 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByTitle find works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher find works 1`] = `
 <b
   title="greeting"
 >
@@ -788,7 +788,7 @@ exports[`DomTestingLibrary ByTitle find works 1`] = `
 </b>
 `;
 
-exports[`DomTestingLibrary ByTitle findAll works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher findAll works 1`] = `
 Array [
   <b
     title="greeting"
@@ -798,7 +798,7 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByTitle get works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher get works 1`] = `
 <b
   title="greeting"
 >
@@ -806,7 +806,7 @@ exports[`DomTestingLibrary ByTitle get works 1`] = `
 </b>
 `;
 
-exports[`DomTestingLibrary ByTitle getAll works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher getAll works 1`] = `
 Array [
   <b
     title="greeting"
@@ -816,7 +816,7 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByTitle query works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher query works 1`] = `
 <b
   title="greeting"
 >
@@ -824,7 +824,115 @@ exports[`DomTestingLibrary ByTitle query works 1`] = `
 </b>
 `;
 
-exports[`DomTestingLibrary ByTitle queryAll works 1`] = `
+exports[`DomTestingLibrary ByTitle function matcher queryAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher find works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher findAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher get works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher getAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher query works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle regexp matcher queryAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher find works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher findAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher get works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher getAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher query works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle string matcher queryAll works 1`] = `
 Array [
   <b
     title="greeting"

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -150,22 +150,6 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByDisplayValue find works 1`] = `
-<input
-  type="text"
-  value="Some value"
-/>
-`;
-
-exports[`DomTestingLibrary ByDisplayValue findAll works 1`] = `
-Array [
-  <input
-    type="text"
-    value="Some value"
-  />,
-]
-`;
-
 exports[`DomTestingLibrary ByDisplayValue function matcher find works 1`] = `
 <input
   name="my-input"
@@ -214,38 +198,6 @@ exports[`DomTestingLibrary ByDisplayValue function matcher queryAll works 1`] = 
 Array [
   <input
     name="my-input"
-    type="text"
-    value="Some value"
-  />,
-]
-`;
-
-exports[`DomTestingLibrary ByDisplayValue get works 1`] = `
-<input
-  type="text"
-  value="Some value"
-/>
-`;
-
-exports[`DomTestingLibrary ByDisplayValue getAll works 1`] = `
-Array [
-  <input
-    type="text"
-    value="Some value"
-  />,
-]
-`;
-
-exports[`DomTestingLibrary ByDisplayValue query works 1`] = `
-<input
-  type="text"
-  value="Some value"
-/>
-`;
-
-exports[`DomTestingLibrary ByDisplayValue queryAll works 1`] = `
-Array [
-  <input
     type="text"
     value="Some value"
   />,
@@ -672,20 +624,6 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByRole find works 1`] = `
-<button>
-  World!
-</button>
-`;
-
-exports[`DomTestingLibrary ByRole findAll works 1`] = `
-Array [
-  <button>
-    World!
-  </button>,
-]
-`;
-
 exports[`DomTestingLibrary ByRole function matcher find works 1`] = `
 <button>
   World!
@@ -721,34 +659,6 @@ exports[`DomTestingLibrary ByRole function matcher query works 1`] = `
 `;
 
 exports[`DomTestingLibrary ByRole function matcher queryAll works 1`] = `
-Array [
-  <button>
-    World!
-  </button>,
-]
-`;
-
-exports[`DomTestingLibrary ByRole get works 1`] = `
-<button>
-  World!
-</button>
-`;
-
-exports[`DomTestingLibrary ByRole getAll works 1`] = `
-Array [
-  <button>
-    World!
-  </button>,
-]
-`;
-
-exports[`DomTestingLibrary ByRole query works 1`] = `
-<button>
-  World!
-</button>
-`;
-
-exports[`DomTestingLibrary ByRole queryAll works 1`] = `
 Array [
   <button>
     World!
@@ -840,24 +750,6 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByTestId find works 1`] = `
-<p
-  data-testid="world"
->
-  World!
-</p>
-`;
-
-exports[`DomTestingLibrary ByTestId findAll works 1`] = `
-Array [
-  <p
-    data-testid="world"
-  >
-    World!
-  </p>,
-]
-`;
-
 exports[`DomTestingLibrary ByTestId function matcher find works 1`] = `
 <p
   data-testid="world"
@@ -903,42 +795,6 @@ exports[`DomTestingLibrary ByTestId function matcher query works 1`] = `
 `;
 
 exports[`DomTestingLibrary ByTestId function matcher queryAll works 1`] = `
-Array [
-  <p
-    data-testid="world"
-  >
-    World!
-  </p>,
-]
-`;
-
-exports[`DomTestingLibrary ByTestId get works 1`] = `
-<p
-  data-testid="world"
->
-  World!
-</p>
-`;
-
-exports[`DomTestingLibrary ByTestId getAll works 1`] = `
-Array [
-  <p
-    data-testid="world"
-  >
-    World!
-  </p>,
-]
-`;
-
-exports[`DomTestingLibrary ByTestId query works 1`] = `
-<p
-  data-testid="world"
->
-  World!
-</p>
-`;
-
-exports[`DomTestingLibrary ByTestId queryAll works 1`] = `
 Array [
   <p
     data-testid="world"

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -166,6 +166,60 @@ Array [
 ]
 `;
 
+exports[`DomTestingLibrary ByDisplayValue function matcher find works 1`] = `
+<input
+  name="my-input"
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue function matcher findAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue function matcher get works 1`] = `
+<input
+  name="my-input"
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue function matcher getAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue function matcher query works 1`] = `
+<input
+  name="my-input"
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue function matcher queryAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
 exports[`DomTestingLibrary ByDisplayValue get works 1`] = `
 <input
   type="text"
@@ -190,6 +244,102 @@ exports[`DomTestingLibrary ByDisplayValue query works 1`] = `
 `;
 
 exports[`DomTestingLibrary ByDisplayValue queryAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher find works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher findAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher get works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher getAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher query works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue regex matcher queryAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher find works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher findAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher get works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher getAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher query works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue string matcher queryAll works 1`] = `
 Array [
   <input
     type="text"
@@ -536,6 +686,48 @@ Array [
 ]
 `;
 
+exports[`DomTestingLibrary ByRole function matcher find works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole function matcher findAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole function matcher get works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole function matcher getAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole function matcher query works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole function matcher queryAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
 exports[`DomTestingLibrary ByRole get works 1`] = `
 <button>
   World!
@@ -564,6 +756,90 @@ Array [
 ]
 `;
 
+exports[`DomTestingLibrary ByRole regex matcher find works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole regex matcher findAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole regex matcher get works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole regex matcher getAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole regex matcher query works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole regex matcher queryAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole string matcher find works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole string matcher findAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole string matcher get works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole string matcher getAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole string matcher query works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole string matcher queryAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
 exports[`DomTestingLibrary ByTestId find works 1`] = `
 <p
   data-testid="world"
@@ -573,6 +849,60 @@ exports[`DomTestingLibrary ByTestId find works 1`] = `
 `;
 
 exports[`DomTestingLibrary ByTestId findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher find works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher get works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher query works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId function matcher queryAll works 1`] = `
 Array [
   <p
     data-testid="world"
@@ -609,6 +939,114 @@ exports[`DomTestingLibrary ByTestId query works 1`] = `
 `;
 
 exports[`DomTestingLibrary ByTestId queryAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher find works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher get works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher query works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId regex matcher queryAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher find works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher get works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher query works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByTestId string matcher queryAll works 1`] = `
 Array [
   <p
     data-testid="world"

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -1,44 +1,156 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DomTestingLibrary configure works using a function 1`] = `
-<p
-  data-custom-test-id="world"
->
-   World!
-</p>
-`;
-
-exports[`DomTestingLibrary configure works using an object 1`] = `
-<p
-  data-custom-test-id="world"
->
-   World!
-</p>
-`;
-
-exports[`DomTestingLibrary getByAltText works 1`] = `
+exports[`DomTestingLibrary ByAltText find works 1`] = `
 <img
   alt="Alt text"
   src=""
 />
 `;
 
-exports[`DomTestingLibrary getByDisplayValue works 1`] = `
+exports[`DomTestingLibrary ByAltText findAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText get works 1`] = `
+<img
+  alt="Alt text"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText getAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByAltText query works 1`] = `
+<img
+  alt="Alt text"
+  src=""
+/>
+`;
+
+exports[`DomTestingLibrary ByAltText queryAll works 1`] = `
+Array [
+  <img
+    alt="Alt text"
+    src=""
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue find works 1`] = `
 <input
   type="text"
   value="Some value"
 />
 `;
 
-exports[`DomTestingLibrary getByLabelText works with function matcher 1`] = `
+exports[`DomTestingLibrary ByDisplayValue findAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue get works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue getAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByDisplayValue query works 1`] = `
+<input
+  type="text"
+  value="Some value"
+/>
+`;
+
+exports[`DomTestingLibrary ByDisplayValue queryAll works 1`] = `
+Array [
+  <input
+    type="text"
+    value="Some value"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText function matcher find works 1`] = `
 <p
   aria-label="message"
 >
-   World!
+  World!
 </p>
 `;
 
-exports[`DomTestingLibrary getByLabelText works with regex matcher 1`] = `
+exports[`DomTestingLibrary ByLabelText function matcher findAll works 1`] = `
+Array [
+  <p
+    aria-label="message"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText function matcher get works 1`] = `
+<p
+  aria-label="message"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByLabelText function matcher getAll works 1`] = `
+Array [
+  <p
+    aria-label="message"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText function matcher query works 1`] = `
+<p
+  aria-label="message"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByLabelText function matcher queryAll works 1`] = `
+Array [
+  <p
+    aria-label="message"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText regex matcher find works 1`] = `
 <section
   aria-labelledby="section-one-header"
 >
@@ -53,40 +165,364 @@ exports[`DomTestingLibrary getByLabelText works with regex matcher 1`] = `
 </section>
 `;
 
-exports[`DomTestingLibrary getByLabelText works with string matcher 1`] = `<input />`;
+exports[`DomTestingLibrary ByLabelText regex matcher findAll works 1`] = `
+Array [
+  <section
+    aria-labelledby="section-one-header"
+  >
+    <h3
+      id="section-one-header"
+    >
+      Section One!
+    </h3>
+    <p>
+      some content
+    </p>
+  </section>,
+]
+`;
 
-exports[`DomTestingLibrary getByPlaceholderText works 1`] = `
+exports[`DomTestingLibrary ByLabelText regex matcher get works 1`] = `
+<section
+  aria-labelledby="section-one-header"
+>
+  <h3
+    id="section-one-header"
+  >
+    Section One!
+  </h3>
+  <p>
+    some content
+  </p>
+</section>
+`;
+
+exports[`DomTestingLibrary ByLabelText regex matcher getAll works 1`] = `
+Array [
+  <section
+    aria-labelledby="section-one-header"
+  >
+    <h3
+      id="section-one-header"
+    >
+      Section One!
+    </h3>
+    <p>
+      some content
+    </p>
+  </section>,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText regex matcher query works 1`] = `
+<section
+  aria-labelledby="section-one-header"
+>
+  <h3
+    id="section-one-header"
+  >
+    Section One!
+  </h3>
+  <p>
+    some content
+  </p>
+</section>
+`;
+
+exports[`DomTestingLibrary ByLabelText regex matcher queryAll works 1`] = `
+Array [
+  <section
+    aria-labelledby="section-one-header"
+  >
+    <h3
+      id="section-one-header"
+    >
+      Section One!
+    </h3>
+    <p>
+      some content
+    </p>
+  </section>,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText string matcher find works 1`] = `<input />`;
+
+exports[`DomTestingLibrary ByLabelText string matcher findAll works 1`] = `
+Array [
+  <input />,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText string matcher get works 1`] = `<input />`;
+
+exports[`DomTestingLibrary ByLabelText string matcher getAll works 1`] = `
+Array [
+  <input />,
+]
+`;
+
+exports[`DomTestingLibrary ByLabelText string matcher query works 1`] = `<input />`;
+
+exports[`DomTestingLibrary ByLabelText string matcher queryAll works 1`] = `
+Array [
+  <input />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText find works 1`] = `
 <input
   placeholder="Enter something"
   type="text"
 />
 `;
 
-exports[`DomTestingLibrary getByTestId works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText findAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText get works 1`] = `
+<input
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText getAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText query works 1`] = `
+<input
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText queryAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByRole find works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole findAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole get works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole getAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByRole query works 1`] = `
+<button>
+  World!
+</button>
+`;
+
+exports[`DomTestingLibrary ByRole queryAll works 1`] = `
+Array [
+  <button>
+    World!
+  </button>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId find works 1`] = `
 <p
   data-testid="world"
 >
-   World!
+  World!
 </p>
 `;
 
-exports[`DomTestingLibrary getByText works with function matcher 1`] = `
+exports[`DomTestingLibrary ByTestId findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId get works 1`] = `
 <p
   data-testid="world"
 >
-   World!
+  World!
 </p>
 `;
 
-exports[`DomTestingLibrary getByText works with regex matcher 1`] = `
+exports[`DomTestingLibrary ByTestId getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByTestId query works 1`] = `
 <p
   data-testid="world"
 >
-   World!
+  World!
 </p>
 `;
 
-exports[`DomTestingLibrary getByText works with string matcher 1`] = `
+exports[`DomTestingLibrary ByTestId queryAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText function matcher find works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText function matcher findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText function matcher get works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText function matcher getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText function matcher query works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText function matcher queryAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText regex matcher find works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText regex matcher findAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText regex matcher get works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText regex matcher getAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText regex matcher query works 1`] = `
+<p
+  data-testid="world"
+>
+  World!
+</p>
+`;
+
+exports[`DomTestingLibrary ByText regex matcher queryAll works 1`] = `
+Array [
+  <p
+    data-testid="world"
+  >
+    World!
+  </p>,
+]
+`;
+
+exports[`DomTestingLibrary ByText string matcher find works 1`] = `
 <b
   title="greeting"
 >
@@ -94,12 +530,104 @@ exports[`DomTestingLibrary getByText works with string matcher 1`] = `
 </b>
 `;
 
-exports[`DomTestingLibrary getByTitle works 1`] = `
+exports[`DomTestingLibrary ByText string matcher findAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByText string matcher get works 1`] = `
 <b
   title="greeting"
 >
   Hello,
 </b>
+`;
+
+exports[`DomTestingLibrary ByText string matcher getAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByText string matcher query works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByText string matcher queryAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle find works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle findAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle get works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle getAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
+`;
+
+exports[`DomTestingLibrary ByTitle query works 1`] = `
+<b
+  title="greeting"
+>
+  Hello,
+</b>
+`;
+
+exports[`DomTestingLibrary ByTitle queryAll works 1`] = `
+Array [
+  <b
+    title="greeting"
+  >
+    Hello,
+  </b>,
+]
 `;
 
 exports[`DomTestingLibrary getNodeText works 1`] = `"Hello,"`;

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -630,6 +630,22 @@ Array [
 ]
 `;
 
+exports[`DomTestingLibrary configure works using a function 1`] = `
+<p
+  data-custom-test-id="world"
+>
+   World!
+</p>
+`;
+
+exports[`DomTestingLibrary configure works using an object 1`] = `
+<p
+  data-custom-test-id="world"
+>
+   World!
+</p>
+`;
+
 exports[`DomTestingLibrary getNodeText works 1`] = `"Hello,"`;
 
 exports[`DomTestingLibrary prettyDOM works 1`] = `

--- a/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/DomTestingLibrary_test.bs.js.snap
@@ -270,14 +270,68 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText find works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText function matcher find works 1`] = `
+<input
+  name="my-input"
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText function matcher findAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText function matcher get works 1`] = `
+<input
+  name="my-input"
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText function matcher getAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText function matcher query works 1`] = `
+<input
+  name="my-input"
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText function matcher queryAll works 1`] = `
+Array [
+  <input
+    name="my-input"
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText regex matcher find works 1`] = `
 <input
   placeholder="Enter something"
   type="text"
 />
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText findAll works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText regex matcher findAll works 1`] = `
 Array [
   <input
     placeholder="Enter something"
@@ -286,14 +340,14 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText get works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText regex matcher get works 1`] = `
 <input
   placeholder="Enter something"
   type="text"
 />
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText getAll works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText regex matcher getAll works 1`] = `
 Array [
   <input
     placeholder="Enter something"
@@ -302,14 +356,62 @@ Array [
 ]
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText query works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText regex matcher query works 1`] = `
 <input
   placeholder="Enter something"
   type="text"
 />
 `;
 
-exports[`DomTestingLibrary ByPlaceholderText queryAll works 1`] = `
+exports[`DomTestingLibrary ByPlaceholderText regex matcher queryAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher find works 1`] = `
+<input
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher findAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher get works 1`] = `
+<input
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher getAll works 1`] = `
+Array [
+  <input
+    placeholder="Enter something"
+    type="text"
+  />,
+]
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher query works 1`] = `
+<input
+  placeholder="Enter something"
+  type="text"
+/>
+`;
+
+exports[`DomTestingLibrary ByPlaceholderText string matcher queryAll works 1`] = `
 Array [
   <input
     placeholder="Enter something"

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,10 +106,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.7.4":
   version "7.8.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
   integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -298,15 +305,6 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.1.0":
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
@@ -334,15 +332,15 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.3.tgz#284815f9995340171a4804819410db7288fd26b3"
-  integrity sha512-zBGQX1Ik+dK3nCdLa9jY5d0DHA4Bx79zaT0Zlv6avOcgop9gf6ff/43Z4rJDDIO2nFsWdoLdoJQY5VQ4TanLsw==
+"@testing-library/dom@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.1.3.tgz#422073afb5ae9bdb910651ac4d51c9ed4382a2f9"
+  integrity sha512-wFMQdKrTwTTlTe6n0KN+KjOtgOV0viIyfr+f+7Csq+1pD0o+ho7FrjCjkNpx6NEsx8jHDtZ4WU3cGOuLc9LvQg==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@types/testing-library__dom" "^6.12.1"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__dom" "^7.0.0"
     aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
+    dom-accessibility-api "^0.4.2"
     pretty-format "^25.1.0"
 
 "@types/babel__core@^7.1.0":
@@ -418,12 +416,12 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
+"@types/testing-library__dom@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.0.0.tgz#c0fb7d1c2495a3d26f19342102142d47500f0319"
+  integrity sha512-1TEPWyqQ6IQ7R1hCegZmFSA3KrBQjdzJW7yC9ybpRcFst5XuPOqBGNr0mTAKbxwI/TrTyc1skeyLJrpcvAf93w==
   dependencies:
-    pretty-format "^24.3.0"
+    pretty-format "^25.1.0"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -434,13 +432,6 @@
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.9.tgz#693e76a52f61a2f1e7fb48c0eef167b95ea4ffd0"
   integrity sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==
-
-"@types/yargs@^13.0.0":
-  version "13.0.8"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
-  integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.4"
@@ -636,11 +627,6 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
-
-ast-types-flow@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
-  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -951,11 +937,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -1130,10 +1111,10 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
+dom-accessibility-api@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.3.tgz#93ca9002eb222fd5a343b6e5e6b9cf5929411c4c"
+  integrity sha512-JZ8iPuEHDQzq6q0k7PKMGbrIdsgBB7TRrtVOUm4nSMCExlg5qQG4KXWTH2k90yggjM4tTumRGwTKJSldMzKyLA==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -3059,16 +3040,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
-
-pretty-format@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
 
 pretty-format@^24.5.0:
   version "24.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,12 +98,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/runtime@^7.4.5":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.0.tgz#49dcbcd637099a55d3a61e590a00d6861393b1b5"
-  integrity sha512-2xsuyZ0R0RBFwjgae5NpXk8FcfH4qovj5cEM5VEeB7KXnKqzaisIu2HSV/mCEISolJJuR4wkViUGYujA8MH9tw==
+"@babel/runtime-corejs3@^7.7.4":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz#8209d9dff2f33aa2616cb319c83fe159ffb07b8c"
+  integrity sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==
   dependencies:
-    regenerator-runtime "^0.13.2"
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.7.4", "@babel/runtime@^7.8.4":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.7.tgz#8fefce9802db54881ba59f90bb28719b4996324d"
+  integrity sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
@@ -290,19 +298,29 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@jest/types@^24.8.0":
-  version "24.8.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.8.0.tgz#f31e25948c58f0abd8c845ae26fcea1491dea7ad"
-  integrity sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==
+"@jest/types@^24.9.0":
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
+  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^12.0.9"
+    "@types/yargs" "^13.0.0"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
-  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+"@jest/types@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.1.0.tgz#b26831916f0d7c381e11dbb5e103a72aed1b4395"
+  integrity sha512-VpOtt7tCrgvamWZh1reVsGADujKigBUFTi19mlRjqEGsE8qH4r3s+skY33dNdXOwyZIvuftZ5tqdF1IgsMejMA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
+"@sheerun/mutationobserver-shim@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
+  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -316,16 +334,16 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.0.tgz#18a7c162a6a79964e731ad7b810022a28218047c"
-  integrity sha512-nAsRvQLr/b6TGNjuHMEbWXCNPLrQYnzqa/KKQZL7wBOtfptUxsa4Ah9aqkHW0ZmCSFmUDj4nFUxWPVTeMu0iCw==
+"@testing-library/dom@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.0.3.tgz#284815f9995340171a4804819410db7288fd26b3"
+  integrity sha512-zBGQX1Ik+dK3nCdLa9jY5d0DHA4Bx79zaT0Zlv6avOcgop9gf6ff/43Z4rJDDIO2nFsWdoLdoJQY5VQ4TanLsw==
   dependencies:
-    "@babel/runtime" "^7.4.5"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    aria-query "3.0.0"
-    pretty-format "^24.8.0"
-    wait-for-expect "^1.2.0"
+    "@babel/runtime" "^7.8.4"
+    "@types/testing-library__dom" "^6.12.1"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.3.0"
+    pretty-format "^25.1.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.0"
@@ -360,6 +378,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -371,9 +394,9 @@
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
 
 "@types/istanbul-lib-report@*":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz#e5471e7fa33c61358dd38426189c037a58433b8c"
-  integrity sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
@@ -395,10 +418,36 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/testing-library__dom@^6.12.1":
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
+  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
+  dependencies:
+    pretty-format "^24.3.0"
+
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.9.tgz#693e76a52f61a2f1e7fb48c0eef167b95ea4ffd0"
   integrity sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==
+
+"@types/yargs@^13.0.0":
+  version "13.0.8"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
+  integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.0":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.4.tgz#7e5d0f8ca25e9d5849f2ea443cf7c402decd8299"
+  integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@wyze/changelog@^1.0.0":
   version "1.0.0"
@@ -476,12 +525,25 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -505,13 +567,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
-  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+aria-query@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
+  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
   dependencies:
-    ast-types-flow "0.0.7"
-    commander "^2.11.0"
+    "@babel/runtime" "^7.7.4"
+    "@babel/runtime-corejs3" "^7.7.4"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -801,6 +863,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -857,10 +927,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "^1.1.1"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
@@ -905,6 +987,11 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1042,6 +1129,11 @@ diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
+
+dom-accessibility-api@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
+  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -1495,6 +1587,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
@@ -2963,6 +3060,16 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+pretty-format@^24.3.0:
+  version "24.9.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
+  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
+  dependencies:
+    "@jest/types" "^24.9.0"
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+    react-is "^16.8.4"
+
 pretty-format@^24.5.0:
   version "24.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.5.0.tgz#cc69a0281a62cd7242633fc135d6930cd889822d"
@@ -2973,15 +3080,15 @@ pretty-format@^24.5.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^24.8.0:
-  version "24.8.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
-  integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
+pretty-format@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.1.0.tgz#ed869bdaec1356fc5ae45de045e2c8ec7b07b0c8"
+  integrity sha512-46zLRSGLd02Rp+Lhad9zzuNZ+swunitn8zIpfD2B4OPCRLXbM87RJT2aBLBWYOznNUML/2l/ReMyWNC80PJBUQ==
   dependencies:
-    "@jest/types" "^24.8.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
+    "@jest/types" "^25.1.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
@@ -3023,6 +3130,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+react-is@^16.12.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 react-is@^16.8.4:
   version "16.8.4"
@@ -3075,10 +3187,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -3550,6 +3662,13 @@ supports-color@^6.0.0, supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -3765,11 +3884,6 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
-
-wait-for-expect@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
-  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
- [x] Upgrade `@testing-library/dom` to 7.x
- [x] Add supports for all queries along with variants (this should fix #1)
  - [x] Queries
    - [x] ByLabelText
    - [x] ByPlaceholderText
      - [x] Add supports for `matcher` type variant
    - [x] ByText
    - [x] ByAltText
      - [x] Add supports for `matcher` type variant
    - [x] ByTitle
      - [x] Add supports for `matcher` type variant
    - [x] ByDisplayValue
      - [x] Add supports for `matcher` type variant
    - [x] ByRole
      - [x] Add supports for `matcher` type variant
    - [x] ByTestId
      - [x] Add supports for `matcher` type variant
  - [x] Variants
    - [x] getBy
    - [x] getAllBy
    - [x] queryBy
    - [x] queryAllBy
    - [x] findBy
    - [x] findAllBy
