### PR TITLE
Fix incorrect returning types

### DIFF
--- a/src/DomTestingLibrary.rei
+++ b/src/DomTestingLibrary.rei
@@ -225,7 +225,7 @@ let getAllByLabelText:
     ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByLabelText:
   (
@@ -237,7 +237,7 @@ let queryByLabelText:
     ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByLabelText:
   (
@@ -249,7 +249,7 @@ let queryAllByLabelText:
     ~options: ByLabelTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByLabelText:
   (
@@ -300,7 +300,7 @@ let getAllByPlaceholderText:
     ~options: ByPlaceholderTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByPlaceholderText:
   (
@@ -312,7 +312,7 @@ let queryByPlaceholderText:
     ~options: ByPlaceholderTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByPlaceholderText:
   (
@@ -324,7 +324,7 @@ let queryAllByPlaceholderText:
     ~options: ByPlaceholderTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByPlaceholderText:
   (
@@ -375,7 +375,7 @@ let getAllByText:
     ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByText:
   (
@@ -387,7 +387,7 @@ let queryByText:
     ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByText:
   (
@@ -399,7 +399,7 @@ let queryAllByText:
     ~options: ByTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByText:
   (
@@ -450,7 +450,7 @@ let getAllByAltText:
     ~options: ByAltTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByAltText:
   (
@@ -462,7 +462,7 @@ let queryByAltText:
     ~options: ByAltTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByAltText:
   (
@@ -474,7 +474,7 @@ let queryAllByAltText:
     ~options: ByAltTextQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByAltText:
   (
@@ -525,7 +525,7 @@ let getAllByTitle:
     ~options: ByTitleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByTitle:
   (
@@ -537,7 +537,7 @@ let queryByTitle:
     ~options: ByTitleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByTitle:
   (
@@ -549,7 +549,7 @@ let queryAllByTitle:
     ~options: ByTitleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByTitle:
   (
@@ -600,7 +600,7 @@ let getAllByDisplayValue:
     ~options: ByDisplayValueQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByDisplayValue:
   (
@@ -612,7 +612,7 @@ let queryByDisplayValue:
     ~options: ByDisplayValueQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByDisplayValue:
   (
@@ -624,7 +624,7 @@ let queryAllByDisplayValue:
     ~options: ByDisplayValueQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByDisplayValue:
   (
@@ -675,7 +675,7 @@ let getAllByRole:
     ~options: ByRoleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByRole:
   (
@@ -687,7 +687,7 @@ let queryByRole:
     ~options: ByRoleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByRole:
   (
@@ -699,7 +699,7 @@ let queryAllByRole:
     ~options: ByRoleQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByRole:
   (
@@ -750,7 +750,7 @@ let getAllByTestId:
     ~options: ByTestIdQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let queryByTestId:
   (
@@ -762,7 +762,7 @@ let queryByTestId:
     ~options: ByTestIdQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  Js.null(Dom.element);
 
 let queryAllByTestId:
   (
@@ -774,7 +774,7 @@ let queryAllByTestId:
     ~options: ByTestIdQuery.options=?,
     Dom.element
   ) =>
-  Dom.element;
+  array(Dom.element);
 
 let findByTestId:
   (

--- a/src/DomTestingLibrary__Queries.re
+++ b/src/DomTestingLibrary__Queries.re
@@ -158,7 +158,7 @@ external _getAllByLabelText:
               ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByLabelText";
 
 let getAllByLabelText = (~matcher, ~options=?, element) =>
@@ -179,7 +179,7 @@ external _queryByLabelText:
               ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByLabelText";
 
 let queryByLabelText = (~matcher, ~options=?, element) =>
@@ -200,7 +200,7 @@ external _queryAllByLabelText:
               ],
     ~options: Js.undefined(ByLabelTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByLabelText";
 
 let queryAllByLabelText = (~matcher, ~options=?, element) =>
@@ -287,7 +287,7 @@ external _getAllByPlaceholderText:
               ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByPlaceholderText";
 
 let getAllByPlaceholderText = (~matcher, ~options=?, element) =>
@@ -308,7 +308,7 @@ external _queryByPlaceholderText:
               ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByPlaceholderText";
 
 let queryByPlaceholderText = (~matcher, ~options=?, element) =>
@@ -329,7 +329,7 @@ external _queryAllByPlaceholderText:
               ],
     ~options: Js.undefined(ByPlaceholderTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByPlaceholderText";
 
 let queryAllByPlaceholderText = (~matcher, ~options=?, element) =>
@@ -412,7 +412,7 @@ external _getAllByText:
               ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByText";
 
 let getAllByText = (~matcher, ~options=?, element) =>
@@ -433,7 +433,7 @@ external _queryByText:
               ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByText";
 
 let queryByText = (~matcher, ~options=?, element) =>
@@ -450,7 +450,7 @@ external _queryAllByText:
               ],
     ~options: Js.undefined(ByTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByText";
 
 let queryAllByText = (~matcher, ~options=?, element) =>
@@ -533,7 +533,7 @@ external _getAllByAltText:
               ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByAltText";
 
 let getAllByAltText = (~matcher, ~options=?, element) =>
@@ -554,7 +554,7 @@ external _queryByAltText:
               ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByAltText";
 
 let queryByAltText = (~matcher, ~options=?, element) =>
@@ -575,7 +575,7 @@ external _queryAllByAltText:
               ],
     ~options: Js.undefined(ByAltTextQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByAltText";
 
 let queryAllByAltText = (~matcher, ~options=?, element) =>
@@ -658,7 +658,7 @@ external _getAllByTitle:
               ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByTitle";
 
 let getAllByTitle = (~matcher, ~options=?, element) =>
@@ -679,7 +679,7 @@ external _queryByTitle:
               ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByTitle";
 
 let queryByTitle = (~matcher, ~options=?, element) =>
@@ -700,7 +700,7 @@ external _queryAllByTitle:
               ],
     ~options: Js.undefined(ByTitleQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByTitle";
 
 let queryAllByTitle = (~matcher, ~options=?, element) =>
@@ -783,7 +783,7 @@ external _getAllByDisplayValue:
               ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByDisplayValue";
 
 let getAllByDisplayValue = (~matcher, ~options=?, element) =>
@@ -804,7 +804,7 @@ external _queryByDisplayValue:
               ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByDisplayValue";
 
 let queryByDisplayValue = (~matcher, ~options=?, element) =>
@@ -825,7 +825,7 @@ external _queryAllByDisplayValue:
               ],
     ~options: Js.undefined(ByDisplayValueQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByDisplayValue";
 
 let queryAllByDisplayValue = (~matcher, ~options=?, element) =>
@@ -908,7 +908,7 @@ external _getAllByRole:
               ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByRole";
 
 let getAllByRole = (~matcher, ~options=?, element) =>
@@ -929,7 +929,7 @@ external _queryByRole:
               ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByRole";
 
 let queryByRole = (~matcher, ~options=?, element) =>
@@ -946,7 +946,7 @@ external _queryAllByRole:
               ],
     ~options: Js.undefined(ByRoleQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByRole";
 
 let queryAllByRole = (~matcher, ~options=?, element) =>
@@ -1025,7 +1025,7 @@ external _getAllByTestId:
               ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "getAllByTestId";
 
 let getAllByTestId = (~matcher, ~options=?, element) =>
@@ -1046,7 +1046,7 @@ external _queryByTestId:
               ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
-  Dom.element =
+  Js.null(Dom.element) =
   "queryByTestId";
 
 let queryByTestId = (~matcher, ~options=?, element) =>
@@ -1067,7 +1067,7 @@ external _queryAllByTestId:
               ],
     ~options: Js.undefined(ByTestIdQuery.options)
   ) =>
-  Dom.element =
+  array(Dom.element) =
   "queryAllByTestId";
 
 let queryAllByTestId = (~matcher, ~options=?, element) =>


### PR DESCRIPTION
Some of returning types are incorrect, this PR addresses that.

| query | before | after |
|-------| ------- | ---- |
| `getAll*` | `Dom.element` | `array(Dom.element)` | 
| `query*` | `Dom.element` | `Js.null(Dom.element)` |
| `queryAll*` | `Dom.element` | `array(Dom.element)` |